### PR TITLE
feat: implement protected routes via Next.js Middleware

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   {
-    ignores: [".next/*", "out/*", "build/*", "next-env.d.ts", "node_modules/*"],
+    ignores: [".next/*", "out/*", "build/*", "next-env.d.ts", "node_modules/*", ".amplify/*"],
   },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-amplify/adapter-nextjs": "^1.7.2",
         "@aws-amplify/ui-react": "^6.9.0",
         "aws-amplify": "^6.16.2",
         "class-variance-authority": "^0.7.1",
@@ -111,6 +112,19 @@
       },
       "peerDependencies": {
         "graphql": "*"
+      }
+    },
+    "node_modules/@aws-amplify/adapter-nextjs": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/adapter-nextjs/-/adapter-nextjs-1.7.2.tgz",
+      "integrity": "sha512-qzj0s0tdN6XsFJrtHAcUMBmITctLxAFCZ0K4/toquuHAcNDMrchKAF94smMnJCOw7hdWTSR6yE9sO82vwj5yIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-jwt-verify": "^4.0.1"
+      },
+      "peerDependencies": {
+        "aws-amplify": "^6.16.1",
+        "next": ">=13.5.0 <17.0.0"
       }
     },
     "node_modules/@aws-amplify/analytics": {
@@ -25970,6 +25984,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-4.0.1.tgz",
+      "integrity": "sha512-kzvi71eD3w/mCpYRUY7cz6DX4bfYihGdI2yV3FYQ2JuZZenqAqDPz0gWj0ew6vlAtdEVBNb7p+Dm2TAIxpVYMA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/axe-core": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-amplify/adapter-nextjs": "^1.7.2",
     "@aws-amplify/ui-react": "^6.9.0",
     "aws-amplify": "^6.16.2",
     "class-variance-authority": "^0.7.1",

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchAuthSession } from "aws-amplify/auth/server";
+import { createServerRunner } from "@aws-amplify/adapter-nextjs";
+import amplifyOutputs from "../amplify_outputs.json";
+
+// Initialize the Amplify server runner once
+const { runWithAmplifyServerContext } = createServerRunner({
+  config: amplifyOutputs,
+});
+
+/**
+ * Public routes that do NOT require authentication.
+ * Everything else is protected by default (deny-by-default).
+ */
+const PUBLIC_ROUTES = ["/login"];
+
+function isPublicRoute(pathname: string): boolean {
+  return PUBLIC_ROUTES.includes(pathname)
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow public routes without auth check
+  if (isPublicRoute(pathname)) {
+    return NextResponse.next();
+  }
+
+  // Deny-by-default: all other routes require authentication
+  const response = NextResponse.next();
+
+  let isAuthenticated = false;
+
+  try {
+    isAuthenticated = await runWithAmplifyServerContext({
+      nextServerContext: { request, response },
+      operation: async (contextSpec) => {
+        const session = await fetchAuthSession(contextSpec);
+        return !!session.tokens;
+      },
+    });
+  } catch {
+    // If session check fails, treat as unauthenticated
+    isAuthenticated = false;
+  }
+
+  if (!isAuthenticated) {
+    const loginUrl = new URL("/login", request.url);
+    // Preserve the original URL as a redirect parameter after login
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization)
+     * - favicon.ico
+     * - static assets (svg, png, jpg, jpeg, gif, webp)
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

Implements Issue #16: protect authenticated routes using Next.js Middleware and AWS Amplify Auth.

## Changes

- **web/src/middleware.ts** *(new)*: Checks Amplify Auth session server-side using \createServerRunner\ from \@aws-amplify/adapter-nextjs\. Unauthenticated users are redirected to \/login\ with a \edirect\ query parameter preserving their original destination.
- **\web/package.json\**: Added \@aws-amplify/adapter-nextjs\ dependency for SSR auth context.
- **\web/eslint.config.mjs\**: Added \.amplify/*\ to the ESLint ignore list to exclude auto-generated CDK artifacts.

## Protected Routes

| Route | Protection |
|-------|-----------|
| \/dashboard\ | Auth required |
| \/tasks\ | Auth required |
| \/login\ | Public |

## Acceptance Criteria

- [x] \middleware.ts\ checks Amplify Auth session state
- [x] Unauthenticated users are redirected to \/login\
- [x] Authenticated users can access protected dashboard routes

## Verification

- TypeScript: \
pm run typecheck\ — passes with no errors
- ESLint: \
pm run lint\ — passes with no errors

Closes #16