### PR TITLE
feat(auth): add redirect-after-login using redirect query param

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -2,12 +2,45 @@
 
 import { Authenticator } from "@aws-amplify/ui-react";
 import "@aws-amplify/ui-react/styles.css";
+import { Hub } from "aws-amplify/utils";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
+
+/**
+ * Inner component that reads search params and handles redirect after login.
+ * Must be wrapped in Suspense because useSearchParams() requires it in Next.js.
+ */
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    // Listen for successful sign-in events from Amplify Auth
+    const unsubscribe = Hub.listen("auth", ({ payload }) => {
+      if (payload.event === "signedIn") {
+        const redirectTo = searchParams.get("redirect");
+        // Security: only allow internal paths (must start with "/" but not "//")
+        const isInternalPath =
+          redirectTo?.startsWith("/") && !redirectTo.startsWith("//");
+        router.replace(isInternalPath ? redirectTo! : "/dashboard");
+      }
+    });
+
+    // Cleanup the listener when the component unmounts
+    return () => unsubscribe();
+  }, [router, searchParams]);
+
+  return <Authenticator />;
+}
 
 export default function LoginPage() {
   return (
     <div className="flex min-h-[100dvh] items-center justify-center p-4 bg-gray-50 dark:bg-gray-900">
       <div className="w-full max-w-md">
-        <Authenticator />
+        {/* Suspense is required by Next.js when using useSearchParams() */}
+        <Suspense fallback={null}>
+          <LoginForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -30,5 +36,7 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
Implement redirect-after-login feature for issue #23.
After a successful sign-in, users are redirected back to the original URL they tried to access (stored in ?redirect= query param by middleware), or to /dashboard as the default.

## Type of Change
- [x] Feature

## Changes
- web/src/app/login/page.tsx: Extract LoginForm component, add Hub.listen('auth') to detect sign-in success, read ?redirect= param via useSearchParams(), and perform safe internal redirect
- web/tsconfig.json: Auto-updated by Next.js build (jsx: preserve)

## Security
- Only internal paths (starting with / but not //) are allowed as redirect targets
- External URLs (e.g. //evil.com) fall back to /dashboard`n
## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Build passed (next build exit code 0)
- [x] Browser verified: S1 redirect URL, S2 default, S3 security fallback

Closes #23