### PR TITLE
feat(data): define Task data model with Amplify Gen2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ dist/
 build/
 
 # AWS Amplify
-amplify/
+.amplify/
 .amplifyrc
 amplify-backup/
 

--- a/web/amplify/auth/resource.ts
+++ b/web/amplify/auth/resource.ts
@@ -1,0 +1,11 @@
+import { defineAuth } from '@aws-amplify/backend';
+
+/**
+ * Define and configure your auth resource
+ * @see https://docs.amplify.aws/gen2/build-a-backend/auth
+ */
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+  },
+});

--- a/web/amplify/backend.ts
+++ b/web/amplify/backend.ts
@@ -1,0 +1,11 @@
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
+
+/**
+ * @see https://docs.amplify.aws/react/build-a-backend/ to add storage, functions, and more
+ */
+defineBackend({
+  auth,
+  data,
+});

--- a/web/amplify/data/resource.ts
+++ b/web/amplify/data/resource.ts
@@ -1,0 +1,22 @@
+import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
+
+// Task model definition for the MyRoadmap app.
+// Authorization: each user can only access their own tasks (owner-based).
+const schema = a.schema({
+  Task: a
+    .model({
+      title: a.string().required(),
+      description: a.string(),
+      status: a.enum(['TODO', 'IN_PROGRESS', 'DONE']),
+    })
+    .authorization((allow) => [allow.owner()]),
+});
+
+export type Schema = ClientSchema<typeof schema>;
+
+export const data = defineData({
+  schema,
+  authorizationModes: {
+    defaultAuthorizationMode: 'userPool',
+  },
+});

--- a/web/amplify/package.json
+++ b/web/amplify/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/web/amplify/tsconfig.json
+++ b/web/amplify/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "$amplify/*": [
+        "../.amplify/generated/*"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implement Task data model in Amplify Gen2 according to #24.
- Replaces default \Todo\ model with \Task\ model (title, description, status)
- Changes authorization to owner-based via userPool.
- Fixes \.gitignore\ to track \mplify/\ folder properly.

## Type of Change
- [x] Feature

## Related Issue
Closes #24

## Acceptance Criteria Met
- [x] Define \Task\ model with required fields
- [x] Add ownership authorization
- [ ] Deploy schema to sandbox (deferred)

## Testing Performed
- [x] Tested locally (\	sc --noEmit\, \
pm run build\ passed)
- [x] No sensitive data exposed