### PR TITLE
fix: resolve AWS Amplify deployment failure (#44)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -44,6 +44,7 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
+        "@parcel/watcher-linux-x64-glibc": "^2.5.6",
         "lightningcss-linux-x64-gnu": "1.31.1"
       }
     },
@@ -22506,6 +22507,26 @@
         "@parcel/watcher-win32-arm64": "2.5.6",
         "@parcel/watcher-win32-ia32": "2.5.6",
         "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/watcher-win32-x64": {

--- a/web/package.json
+++ b/web/package.json
@@ -46,6 +46,7 @@
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {
+    "@parcel/watcher-linux-x64-glibc": "^2.5.6",
     "lightningcss-linux-x64-gnu": "1.31.1"
   },
   "overrides": {


### PR DESCRIPTION
Closes #44

Adds @parcel/watcher-linux-x64-glibc to optionalDependencies to fix Amplify Linux container build failure.