### PR TITLE
fix: replace npm ci with npm install in amplify.yml (#48)

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,13 +5,13 @@ applications:
       phases:
         build:
           commands:
-            - npm ci
+            - npm install
             - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
     frontend:
       phases:
         preBuild:
           commands:
-            - npm ci
+            - npm install
         build:
           commands:
             - npm run build


### PR DESCRIPTION
Closes #48

## Problem
The Amplify backend build phase was using 
pm ci, which strictly requires a lock file that contains all packages. The WSL-generated package-lock.json was missing many AWS CDK and Smithy dependencies, causing the backend build to fail.

## Solution
Replace 
pm ci with 
pm install in both backend and frontend phases of mplify.yml. This allows npm to resolve packages flexibly without strict lockfile validation.