### PR TITLE
feat(ci): optimize pipeline with node_modules caching strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-          cache: "npm"
-          cache-dependency-path: "web/package-lock.json"
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('web/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |
           rm -f package-lock.json
           npm install

--- a/amplify.yml
+++ b/amplify.yml
@@ -21,5 +21,5 @@ applications:
           - "**/*"
       cache:
         paths:
-          - .next/cache/**/*
-          - node_modules/**/*
+          - web/.next/cache/**/*
+          - web/node_modules/**/*


### PR DESCRIPTION
## Description

This PR implements CI/CD optimizations to reduce execution time and improve build stability.

- **GitHub Actions**: Introduced `actions/cache@v4` to cache `node_modules` using `web/package.json` as the key. This allows skipping `npm install` when the cache is hit, significantly reducing CI run time.
- **AWS Amplify**: Updated `amplify.yml` cache paths to include the `web/` prefix to correctly target the `appRoot` directory.

## Related Issue

Closes #52

## Acceptance Criteria Met

- [x] Implement node_modules caching in GitHub Actions
- [x] Conditional dependency installation
- [x] Correct Amplify cache paths for web directory

## Testing Performed

- Verified YAML structure and diff
- Verified file paths in the workspace
