### PR TITLE
feat(ci): add scheduled and restricted manual Amplify deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Amplify Deploy
+
+on:
+  schedule:
+    - cron: "0 14 * * 0" # Weekly on Sundays at 23:00 JST (14:00 UTC)
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Deploy reason"
+        required: false
+        default: "Manual deploy"
+
+jobs:
+  deploy-scheduled:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Amplify build (Scheduled)
+        run: |
+          aws amplify start-job \
+            --app-id ${{ secrets.AMPLIFY_APP_ID }} \
+            --branch-name main \
+            --job-type RELEASE
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+
+      - name: Generate Execution Report
+        run: |
+          echo "## 🚀 Amplify Deployment Report (Scheduled)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: Scheduled (Sunday 23:00 JST)" >> $GITHUB_STEP_SUMMARY
+          echo "- **App ID**: \`${{ secrets.AMPLIFY_APP_ID }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: \`main\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: Job started successfully" >> $GITHUB_STEP_SUMMARY
+
+  deploy-manual:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Trigger Amplify build (Manual)
+        run: |
+          aws amplify start-job \
+            --app-id ${{ secrets.AMPLIFY_APP_ID }} \
+            --branch-name main \
+            --job-type RELEASE
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+
+      - name: Generate Execution Report
+        run: |
+          echo "## 🚀 Amplify Deployment Report (Manual)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Reason**: ${{ github.event.inputs.reason }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **App ID**: \`${{ secrets.AMPLIFY_APP_ID }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: \`main\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: Job started successfully (Approved by Admin)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

This PR implements a hybrid deployment strategy for AWS Amplify to optimize costs and provide administrative control.

- **Weekly Scheduled Deployment**: Automatically triggers an Amplify build every Sunday at 23:00 JST.
- **Restricted Manual Deployment**: Adds a `workflow_dispatch` trigger that requires approval from an administrator via the `production` environment.
- **Execution Reporting**: Automatically generates a GitHub Step Summary for each deployment, providing visibility into the trigger source (actor or schedule) and target App ID.

## Related Issue

Closes #53

## Acceptance Criteria Met

- [x] Weekly Sunday 23:00 JST schedule
- [x] Manual trigger with admin approval (Environment-based)
- [x] Execution summary report in GitHub Actions

## Testing Performed

- Verified YAML structure and cron expression.
- Verified job logic (separate jobs for schedule and manual for access control).
