### PR TITLE
fix(ci): correct amplify cache paths relative to appRoot

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -21,5 +21,5 @@ applications:
           - "**/*"
       cache:
         paths:
-          - web/.next/cache/**/*
-          - web/node_modules/**/*
+          - .next/cache/**/*
+          - node_modules/**/*


### PR DESCRIPTION
When \ppRoot\ is specified, cache paths are relative to that root. The \web/\ prefix caused Amplify to incorrectly look for \web/web/node_modules\.