### PR TITLE
docs(i18n): add site-wide bilingual support and refactor documentation structure

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -12,7 +12,7 @@ trigger: always_on
 <optional body>
 ```
 
-Types: feat, fix, refactor, docs, test, chore, perf, ci
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
 Example: `feat(task): add priority filter component`
 
 ## Pull Request Workflow
@@ -21,10 +21,13 @@ When creating PRs:
 1. Analyze full commit history (not just latest commit)
 2. Draft comprehensive PR summary
 3. Include test plan with TODOs
-4. Execute PR creation via `/create-pr` workflow
+4. Execute PR creation via [PR Engineering](../workflows/pr-engineering.md) or `/create-pr` workflow
 
 > [!CAUTION]
-> NEVER push directly to `main`. Always create a feature branch and PR.
+> **NEVER** modify files directly on the `main` branch. Always create a feature branch (`git checkout -b feat/...`) before making any edits.
+
+> [!CAUTION]
+> **NEVER** push directly to `main`. Always create a feature branch and PR.
 
 ## Pre-PR Checklist
 
@@ -33,4 +36,12 @@ Before pushing a branch or creating a PR:
 - [ ] Tests pass (`cd web && npx vitest run`)
 - [ ] Coverage meets 80%+ threshold (`cd web && npx vitest run --coverage`)
 - [ ] Types are correct (`cd web && npx tsc --noEmit`)
-- [ ] Self-reviewed using `/code-review` workflow
+- [ ] Self-reviewed using `/code-review` or `/verification-engineering` workflow
+
+## Autonomous Loop Engineering Guidelines
+
+When running autonomous workflows ([Loop Engineering](../workflows/loop-engineering.md)):
+1. **Branch Protection**: The AI agent MUST verify active branch (`git branch --show-current`) is NOT `main` before ANY file modification.
+2. **Micro-Task Iterations**: Break tasks into XS (< 1h) or S (1-2h) sizing. Run test verification after each micro-step.
+3. **Self-Correction Circuit Breaker**: Maximum 3 consecutive retries for the same failure. On 4th failure, STOP execution and request human feedback.
+4. **Checkpointing**: Create a clean git commit after every successfully verified micro-task.

--- a/.agent/rules/security.md
+++ b/.agent/rules/security.md
@@ -6,33 +6,37 @@ trigger: always_on
 
 ## Mandatory Security Checks
 
-Before ANY commit:
-- [ ] No hardcoded secrets (API keys, passwords, tokens)
-- [ ] All user inputs validated
-- [ ] SQL injection prevention
-- [ ] XSS prevention (sanitized HTML)
+Before ANY commit or PR creation:
+- [ ] No hardcoded secrets (API keys, passwords, tokens, AWS Cognito credentials)
+- [ ] All user inputs validated at system boundaries (e.g., Zod schemas)
+- [ ] SQL/NoSQL injection prevention
+- [ ] XSS prevention (sanitized HTML, DOMPurify)
 - [ ] CSRF protection enabled
-- [ ] Authentication/authorization verified
-- [ ] Rate limiting on all endpoints
+- [ ] Authentication/authorization verified on all routes
+- [ ] Rate limiting on sensitive endpoints
 - [ ] Error messages don't leak sensitive data
+
+## Autonomous AI Agent Security Rules (STRICTLY ENFORCED)
+
+1. **Path Sanitization**:
+   - NEVER output absolute local machine paths (`C:\Users\...`, `/home/...`) in commit messages, PR descriptions, Issues, or artifacts.
+   - Always use relative paths starting from the project root (`./web/...`, `./.agent/...`).
+2. **Log & Transcript Masking**:
+   - Mask local usernames, IP addresses, or machine-specific environment variables in agent logs.
+3. **Secret Leakage Prevention**:
+   - NEVER commit `.env.local` or environment files containing real secrets.
+   - Automatically abort PR creation if static analysis detects potential hardcoded API keys.
 
 ## AWS & Amplify Specifics
 
-- **Cognito & DataStore**: Never expose admin credentials or overly permissive rules.
+- **Cognito & DataStore**: Never expose admin credentials or overly permissive GraphQL/DynamoDB authorization rules.
 - **Environment Variables**: NEVER commit `.env.local` or any file containing real AWS keys, database URIs, or API secrets.
-
-## Secret Management
-
-- NEVER hardcode secrets in source code
-- ALWAYS use environment variables or a secret manager
-- Validate that required secrets are present at startup
-- Rotate any secrets that may have been exposed
 
 ## Security Response Protocol
 
-If security issue found:
-1. STOP immediately
-2. Use **code-review** workflow to identify scope
-3. Fix CRITICAL issues before continuing
-4. Rotate any exposed secrets
-5. Review entire codebase for similar issues
+If a security issue is found:
+1. STOP immediately.
+2. Use [Verification Engineering](../workflows/verification-engineering.md) or `/code-review` to identify scope.
+3. Fix CRITICAL issues before continuing.
+4. Rotate any exposed secrets immediately.
+5. Review the codebase for similar patterns.

--- a/.agent/shared/architecture.md
+++ b/.agent/shared/architecture.md
@@ -1,0 +1,150 @@
+# Architecture Specification for Autonomous AI Workflows
+
+This document presents the complete architecture of the autonomous software engineering workflow system.
+
+---
+
+## 1. Overall System Architecture
+
+```mermaid
+graph TD
+    subgraph "Core Orchestration"
+        PE["Prompt Engineering Workflow"]
+        CE["Context Engineering Workflow"]
+        PL["Planning Engineering Workflow"]
+        LE["Loop Engineering Workflow"]
+    end
+
+    subgraph "Execution & Verification"
+        HE["Harness Engineering Workflow"]
+        VE["Verification Engineering Workflow"]
+        PRE["PR Engineering Workflow"]
+    end
+
+    subgraph "Shared Foundation Layer"
+        GL["Glossary (.agent/shared/glossary.md)"]
+        DP["Design Principles (.agent/shared/design-principles.md)"]
+        SG["Guardrails (.agent/shared/guardrails.md)"]
+        PC["Project Config (.agent/shared/project-config.md)"]
+    end
+
+    PE --> CE
+    CE --> PL
+    PL --> LE
+    LE <--> HE
+    LE --> VE
+    VE --> PRE
+
+    PE -.-> Shared Foundation Layer
+    CE -.-> Shared Foundation Layer
+    PL -.-> Shared Foundation Layer
+    LE -.-> Shared Foundation Layer
+    HE -.-> Shared Foundation Layer
+    VE -.-> Shared Foundation Layer
+    PRE -.-> Shared Foundation Layer
+```
+
+---
+
+## 2. Workflow Dependency Graph
+
+```mermaid
+graph LR
+    A["Prompt Engineering"] -->|Instruction Contracts| B["Context Engineering"]
+    B -->|Assembled Context & Token Budget| C["Planning Engineering"]
+    C -->|Task Roadmap & Acceptance Criteria| D["Loop Engineering"]
+    D <-->|Executes Test/Lint/Build| E["Harness Engineering"]
+    D -->|Staged Code Changes| F["Verification Engineering"]
+    F -->|Quality Gate Status & Artifacts| G["PR Engineering"]
+```
+
+---
+
+## 3. Data Flow Diagram
+
+```mermaid
+flowchart TD
+    UserReq["User Feature Request / Issue"] --> PE_Phase["Prompt Engineering Workflow"]
+    PE_Phase -->|Validated Prompt Contract| CE_Phase["Context Engineering Workflow"]
+    
+    CE_Phase -->|Context Bundle & Token Budget| PL_Phase["Planning Engineering Workflow"]
+    PL_Phase -->|Decomposed Micro-Tasks| LE_Phase["Loop Engineering Workflow"]
+    
+    subgraph "Iterative Execution Loop"
+        LE_Phase -->|Execute Code Change| HE_Phase["Harness Engineering Workflow"]
+        HE_Phase -->|Test/Build Output| LE_Phase
+    end
+
+    LE_Phase -->|Completed Code & Checkpoints| VE_Phase["Verification Engineering Workflow"]
+    VE_Phase -->|Quality Gate Report| PRE_Phase["PR Engineering Workflow"]
+    PRE_Phase -->|Pull Request & Evidence Report| GitHubPR["GitHub PR Created & User Notified"]
+```
+
+---
+
+## 4. State Transition Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> PromptValidation: User Invokes Task
+    PromptValidation --> ContextAssembly: Prompt Validated
+    ContextAssembly --> TaskPlanning: Context Built
+    TaskPlanning --> LoopExecution: Roadmap Approved
+    
+    state LoopExecution {
+        [*] --> PickMicroTask
+        PickMicroTask --> WriteTest_RED: Micro-Task Sizing OK
+        WriteTest_RED --> Implement_GREEN: Test Fails As Expected
+        Implement_GREEN --> HarnessCheck: Run Verification
+        
+        HarnessCheck --> SelfCorrection: Failure (Retry < 3)
+        SelfCorrection --> Implement_GREEN: Retry Attempt
+        HarnessCheck --> CheckpointCommit: All Checks Pass
+        
+        HarnessCheck --> Halted: Failure (Retry >= 3)
+        CheckpointCommit --> PickMicroTask: Next Task Available
+        CheckpointCommit --> LoopComplete: All Tasks Passed
+    }
+
+    LoopExecution --> QualityGateCheck: Loop Complete
+    QualityGateCheck --> PRCreation: Quality Gate Passed (APPROVED)
+    QualityGateCheck --> LoopExecution: Quality Gate Failed (Re-enter Loop)
+    PRCreation --> [*]: PR Created
+    Halted --> [*]: User Intervention Required
+```
+
+---
+
+## 5. Recommended Execution Pipeline Order
+
+| Step | Workflow Module | Primary Responsibilities |
+|:---:|:---|:---|
+| 1 | **Prompt Engineering** | Instruction design, role contracts, output validation, template optimization. |
+| 2 | **Context Engineering** | Repository exploration, token budget tracking, context pruning, memory loading. |
+| 3 | **Harness Engineering** | Environment execution, test running, linting, build checks, sandboxing. |
+| 4 | **Planning Engineering** | Requirement breakdown, micro-task sizing, risk identification, roadmap generation. |
+| 5 | **Loop Engineering** | Autonomous TDD execution, iteration management, self-correction, state checkpointing. |
+| 6 | **Verification Engineering** | Architecture evaluation, security auditing, quality gates, performance checks. |
+| 7 | **PR Engineering** | Change summarization, commit formatting, evidence collation, Pull Request generation. |
+
+---
+
+## 6. Directory Structure Overview
+
+```
+.agent/
+├── shared/
+│   ├── glossary.md
+│   ├── design-principles.md
+│   ├── guardrails.md
+│   ├── project-config.md
+│   └── architecture.md
+└── workflows/
+    ├── prompt-engineering.md
+    ├── context-engineering.md
+    ├── harness-engineering.md
+    ├── planning-engineering.md
+    ├── loop-engineering.md
+    ├── verification-engineering.md
+    └── pr-engineering.md
+```

--- a/.agent/shared/design-principles.md
+++ b/.agent/shared/design-principles.md
@@ -1,0 +1,55 @@
+# Shared Design Principles
+
+This document defines core principles governing the architecture and execution of autonomous engineering workflows.
+
+---
+
+## 1. Single Responsibility Principle (SRP)
+
+* **Rule**: Every workflow module owns exactly one distinct domain of engineering responsibility.
+* **Rationale**: Prevents bloated, monolithic prompts and eliminates conflicting instructions across execution steps.
+* **Enforcement**: If a workflow attempts to perform actions belonging to another domain (e.g., Planning Engineering attempting to run tests directly), it MUST delegate to the appropriate upstream/downstream workflow.
+
+---
+
+## 2. Composability & Standardized Interfaces
+
+* **Rule**: Workflows interact exclusively via structured, machine-readable inputs and outputs.
+* **Rationale**: Enables building complex execution pipelines by chaining independent workflows together like UNIX pipes.
+* **Enforcement**: Every workflow specification MUST define explicit JSON/Markdown schema formats for its `Inputs` and `Outputs`.
+
+---
+
+## 3. Stateless Execution
+
+* **Rule**: Workflows must not rely on implicit session memory or unstated environmental assumptions.
+* **Rationale**: Autonomous agents may experience context resets, long-running breaks, or execution across multiple subagents.
+* **Enforcement**: All state required for execution MUST be supplied directly via Context Engineering or passed explicitly as structured inputs.
+
+---
+
+## 4. Safety First & Defense in Depth
+
+* **Rule**: Safety mechanisms take priority over autonomous execution speed or convenience.
+* **Rationale**: Prevents accidental data loss, branch corruption, secret exposure, or infinite execution loops.
+* **Enforcement**:
+  - Never execute directly on the `main` branch.
+  - Enforce hard retry limits (max 3 attempts per failure).
+  - Require explicit user approval for destructive actions.
+  - Revert to known-good checkpoints upon unrecoverable failure.
+
+---
+
+## 5. Agent-Friendly & Machine-Readable First
+
+* **Rule**: Workflows, logs, and output schemas must be optimized for parsing by LLMs and automated CLI tools.
+* **Rationale**: Human-oriented unstructured text leads to parsing ambiguity and unreliable downstream processing.
+* **Enforcement**: Use clear Markdown headings, JSON output contracts, strict regexable conventions, and explicit status codes.
+
+---
+
+## 6. Vendor Neutrality & Portability
+
+* **Rule**: Workflows must remain decoupled from specific IDEs, AI vendors, or underlying command structures.
+* **Rationale**: Workflows should run identically on Claude Code, Gemini CLI, Codex, OpenHands, or custom agent drivers.
+* **Enforcement**: Use abstract template variables (`{{TEST_COMMAND}}`, `{{TYPE_CHECK_COMMAND}}`) backed by project-level configuration mappings (`project-config.md`).

--- a/.agent/shared/glossary.md
+++ b/.agent/shared/glossary.md
@@ -1,0 +1,61 @@
+# Shared Glossary for Autonomous Engineering Workflows
+
+This document establishes standard terminology used across all autonomous AI agent workflows.
+
+---
+
+## Terms and Definitions
+
+### Acceptance Criteria
+Formal, verifiable requirements that a task or feature must satisfy before being considered complete.
+
+### Agent-First
+A design methodology where tools, instructions, documentation, and workflows are structured primarily for autonomous AI execution rather than manual human operation.
+
+### Approval Hook
+A hard stop in execution where an autonomous agent MUST request human consent before proceeding (e.g., executing destructive actions, pushing to production).
+
+### Checkpoint
+A state snapshot (git commit or local stash) created by the agent after passing a verification step, enabling safe rollback if subsequent steps fail.
+
+### Context Engineering
+The workflow responsible for discovering, filtering, assembling, refreshing, and managing token budgets for repository information supplied to the agent.
+
+### Guardrail
+A strict rule, constraint, or automated safety check enforced on agent actions to prevent runaway behavior, security leaks, or repository corruption.
+
+### Harness Engineering
+The workflow responsible for configuring and running tools (tests, compilers, linters, static analyzers, security scanners) in an isolated execution environment.
+
+### Loop Engineering
+The workflow responsible for orchestrating iterative, autonomous development steps (planning → TDD → execution → verification → self-correction).
+
+### Micro-Task
+A small, self-contained unit of work with a target completion estimate of **XS** (< 1 hour) or **S** (1-2 hours) designed to minimize cognitive overhead and error blast radius.
+
+### Planning Engineering
+The workflow responsible for analyzing goals, building dependency graphs, decomposing complex requirements into micro-tasks, and mapping risks.
+
+### PR Engineering
+The workflow responsible for compiling change summaries, conventional commits, reviewer checklists, test evidence, and initiating Pull Requests.
+
+### Prompt Engineering
+The workflow responsible for instruction design, role definition, output contract validation, and reusable prompt templates.
+
+### Quality Gate
+A threshold of metrics (e.g., test pass rate, code coverage percentage, zero critical security findings) that must be cleared to transition between workflow phases.
+
+### Retry Policy
+A predefined mechanism governing how many times an agent can attempt self-correction on a failing step (default: maximum 3 consecutive retries) before halting.
+
+### Rollback Strategy
+A procedure for reverting the repository to a previous known-good Checkpoint when a non-recoverable error or safety violation occurs.
+
+### Single Responsibility Principle (SRP)
+The constraint that every workflow module owns exactly one distinct domain of responsibility without functional overlap.
+
+### Token Budget
+The maximum allowed context size per model invocation, managed to prevent truncation, degradation of reasoning, or out-of-memory errors.
+
+### Verification Engineering
+The workflow responsible for deep quality checks, architecture review, security audits, performance profiling, and acceptance verification.

--- a/.agent/shared/guardrails.md
+++ b/.agent/shared/guardrails.md
@@ -1,0 +1,76 @@
+# Shared Guardrails & Safety Policies
+
+This document establishes universal safety mechanisms, constraints, and failure recovery protocols enforced across all autonomous agent operations.
+
+---
+
+## 1. Branch Protection & Isolation
+
+* **Rule**: Operations MUST NOT modify files or commit directly on the `main` branch.
+* **Validation Procedure**:
+  - Before any edit, verify active branch using `git branch --show-current`.
+  - If current branch is `main` (or protected base branch), immediately create/switch to a feature branch (`feat/*`, `fix/*`, `chore/*`).
+* **Violation Action**: Immediately halt execution and alert user if branch validation fails.
+
+---
+
+## 2. Path Sanitization & Privacy Control
+
+* **Rule**: Local absolute file paths (e.g., `C:\Users\...`, `/home/...`) MUST NEVER be output in commit messages, Pull Requests, issues, or persistent log files.
+* **Sanitization Standard**:
+  - Use project-root relative paths (`./web/...`, `./.agent/...`).
+  - Mask local machine identifiers with placeholders (e.g., `<project_root>`, `[USER_HOME]`).
+
+---
+
+## 3. Secret Protection & Credential Masking
+
+* **Rule**: Secrets, passwords, API tokens, AWS keys, or `.env` parameters MUST NEVER be committed to repository files or exposed in output text.
+* **Scan Rules**:
+  - Check staged files for regex patterns matching API keys (`sk-*`, `AKIA*`, tokens).
+  - Verify `.env.local` or environment files containing real keys are included in `.gitignore`.
+
+---
+
+## 4. Execution Retry Policy & Circuit Breakers
+
+* **Rule**: Strict limits on retries to prevent infinite execution loops and token exhaustion.
+* **Dual Circuit Breaker Logic**:
+  - **Task-Level Limit (`TaskRetryCount`)**: Maximum of **3 consecutive retries** for the same error on a single micro-task.
+  - **Cumulative Loop Limit (`TotalRetryBudget`)**: Maximum of **5 cumulative retries** across the entire loop execution session.
+* **Retry Counter Procedure**:
+  - Attempt 1: Analyze un-truncated error log → apply targeted fix.
+  - Attempt 2: Re-read context & dependencies → apply alternative minimal fix.
+  - Attempt 3: Run comprehensive check → apply final fix.
+  - **Trigger (TaskRetryCount > 3 OR TotalRetryCount > TotalRetryBudget)**: Trigger **Circuit Breaker** → HALT execution immediately and request human intervention.
+
+---
+
+## 5. Approval Checkpoints (Human-in-the-Loop)
+
+* **Rule**: Explicit user authorization is MANDATORY prior to executing any high-risk operations:
+  - Deleting directories or core repository files.
+  - Resetting databases or running destructive migrations.
+  - Force-pushing to remote branches.
+  - Merging Pull Requests into `main`.
+
+---
+
+## 6. Checkpointing & Rollback Policy
+
+* **Rule**: Create a git commit or stash checkpoint before starting complex modifications.
+* **Rollback Protocol**:
+  1. Detect unrecoverable failure or circuit breaker trip.
+  2. Execute `git reset --hard <last-checkpoint-sha>` or `git checkout -- .`.
+  3. Clean untracked garbage files (`git clean -fd`).
+  4. Output explicit rollback status report to user.
+
+---
+
+## 7. Token & Cost Optimization Limits
+
+* **Rule**: Prevent runaway token consumption and API cost inflation during autonomous agent execution.
+* **Cost Safety Limits**:
+  - **Max Scope Per Micro-Task**: Maximum **3 files modified** and **< 200 lines changed** per task. If a task requires wider changes, it MUST be re-decomposed by Planning Engineering.
+  - **Max Tasks Per Run (`MaxTasksPerRun`)**: Maximum **5 micro-tasks** executed in a single continuous loop invocation.
+  - **Targeted Context Refresh**: Context Engineering MUST refresh memory only for files actually modified during the checkpoint, avoiding full repository re-scans.

--- a/.agent/shared/project-config.md
+++ b/.agent/shared/project-config.md
@@ -1,0 +1,52 @@
+# Project Configuration & Template Variable Mappings
+
+This file maps generic template variables used in autonomous workflows to concrete project commands and parameters.
+
+---
+
+## 1. Execution Commands
+
+| Variable Name | Mapping / Value | Description |
+|:---|:---|:---|
+| `{{TEST_COMMAND}}` | `cd web && npx vitest run` | Command to run unit/integration test suite |
+| `{{TEST_WATCH_COMMAND}}` | `cd web && npx vitest` | Command to run test watcher |
+| `{{TEST_COVERAGE_COMMAND}}` | `cd web && npx vitest run --coverage` | Command to calculate test coverage |
+| `{{TYPE_CHECK_COMMAND}}` | `cd web && npx tsc --noEmit` | Canonical TypeScript type-check command |
+| `{{LINT_COMMAND}}` | `cd web && npx eslint src/` | Command for code linting |
+| `{{FORMAT_COMMAND}}` | `npx prettier --write src/` | Code formatting command |
+| `{{BUILD_COMMAND}}` | `cd web && npm run build` | Production build command |
+| `{{SECURITY_SCAN_COMMAND}}` | `npm audit` | Security vulnerability scan command |
+
+---
+
+## 2. Thresholds & Limits
+
+| Variable Name | Value | Description |
+|:---|:---|:---|
+| `{{COVERAGE_THRESHOLD}}` | `80` | Minimum required overall test coverage percentage |
+| `{{CRITICAL_COVERAGE_THRESHOLD}}` | `100` | Minimum test coverage for auth & security logic |
+| `{{MAX_RETRY_COUNT}}` | `3` | Maximum consecutive self-correction retries per step |
+| `{{MAX_FILE_LINES}}` | `800` | Maximum recommended line count per file |
+| `{{MAX_FUNCTION_LINES}}` | `50` | Maximum recommended line count per function |
+| `{{MAX_NESTING_DEPTH}}` | `4` | Maximum recommended nesting level |
+
+---
+
+## 3. Branching & Git Conventions
+
+| Variable Name | Value | Description |
+|:---|:---|:---|
+| `{{BASE_BRANCH}}` | `main` | Production base branch |
+| `{{BRANCH_PREFIXES}}` | `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` | Allowed feature branch prefixes |
+| `{{COMMIT_FORMAT}}` | `Conventional Commits (<type>(<scope>): <description>)` | Required commit style |
+
+---
+
+## 4. Tech Stack Context
+
+| Parameter | Value |
+|:---|:---|
+| Frontend Framework | Next.js (App Router), TypeScript, Tailwind CSS, shadcn/ui |
+| Backend & Infrastructure | AWS Amplify Gen 2 (TypeScript IaC) |
+| Auth & DB | AWS Cognito, Amazon DynamoDB |
+| Test Framework | Vitest, Testing Library |

--- a/.agent/workflows/code-review.md
+++ b/.agent/workflows/code-review.md
@@ -1,50 +1,63 @@
 ---
-description: Code Review
+description: Code Review workflow for human and automated review using code-reviewer, typescript-reviewer skills, and Verification Engineering standards.
 ---
 
-# Code Review
+# Code Review (`/code-review`)
 
-Comprehensive security and quality review of uncommitted changes. This workflow utilizes the `code-reviewer` and `typescript-reviewer` skills.
+Comprehensive security and quality review of uncommitted changes. This workflow utilizes the `code-reviewer` and `typescript-reviewer` skills and aligns with [Verification Engineering](./verification-engineering.md).
 
-1. Get changed files: `git diff --name-only HEAD`
+---
 
-2. For each changed file, check for:
+## 🛡️ Guardrails & Strict Rules
+
+> [!CAUTION]
+> **Branch Protection**: NEVER execute code reviews directly on `main` to commit fixes. Always ensure changes are on a feature branch (`feat/*`, `fix/*`).
+
+> [!CAUTION]
+> **Zero Tolerance**: NEVER approve code containing CRITICAL or HIGH security findings (hardcoded secrets, unhandled injection, absolute machine path leaks).
+
+> [!IMPORTANT]
+> **Confidence Threshold**: Only report issues where confidence of a defect is > 80% to avoid review noise.
+
+---
+
+## Review Process
+
+1. **Get Changed Files**: `git diff --name-only HEAD`
+2. **Execute Diagnostic Commands** (via [project-config.md](../shared/project-config.md)):
+   - Type check: `{{TYPE_CHECK_COMMAND}}` (`cd web && npx tsc --noEmit`)
+   - Test suite: `{{TEST_COMMAND}}` (`cd web && npx vitest run`)
+3. **Inspect Checklist Categories**:
 
 **Security Issues (CRITICAL):**
 - Hardcoded credentials, API keys, AWS tokens
-- SQL/NoSQL injection
-- XSS vulnerabilities
-- Missing input validation
-- Insecure dependencies
-- Path traversal risks
+- SQL/NoSQL injection & XSS vulnerabilities
+- Missing input validation (Zod schema boundary validation)
+- Insecure dependencies or absolute local path leaks
 - AWS Amplify specific (Cognito token leaks, DataStore permissive rules)
 
 **Code Quality (HIGH):**
-- Functions > 50 lines
-- Files > 800 lines
+- Functions > 50 lines / Files > 800 lines
 - Nesting depth > 4 levels
-- Missing error handling
-- console.log statements
-- TODO/FIXME comments
-- Server/Client boundary violations (React Server Components vs Client Components)
+- Missing error handling / Swallowed exceptions
+- `console.log` statements or dead code
+- Server/Client boundary violations in Next.js React Server Components
 
 **TypeScript Check (HIGH):**
-- `any` without justification
-- non-null assertion abuse (`!`)
-- `as` casts that bypass checks
-- `cd web && npx tsc --noEmit` fails
+- `any` without explicit justification
+- Non-null assertion abuse (`!`)
+- `as` casts that bypass type checks
+- `{{TYPE_CHECK_COMMAND}}` failures
 
 **Best Practices (MEDIUM):**
-- Mutation patterns (use immutable instead)
-- Missing tests for new code (check `cd web && npm test`)
-- Dependency arrays missing in `useEffect`
+- Mutation patterns (MUST use immutable objects)
+- Missing unit tests for new logic (coverage must meet `{{COVERAGE_THRESHOLD}}`%)
+- Dependency arrays missing in `useEffect` / `useCallback`
 
-3. Generate report with:
-   - Severity: CRITICAL, HIGH, MEDIUM, LOW
-   - File location and line numbers
-   - Issue description
-   - Suggested fix
-
-4. Block PR creation or git actions if CRITICAL or HIGH issues are found.
-
-Never approve code with security vulnerabilities!
+4. **Generate Structured Report**:
+   - Severity: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`
+   - File location (relative paths only) and line numbers
+   - Detailed issue description & suggested fix snippet
+5. **Issue Verdict**:
+   - `APPROVE` / `WARNING` / `BLOCK`
+   - Block PR creation or git merge actions if CRITICAL or HIGH issues exist.

--- a/.agent/workflows/context-engineering.md
+++ b/.agent/workflows/context-engineering.md
@@ -1,0 +1,167 @@
+---
+description: Reusable context engineering workflow for repository discovery, memory hierarchy assembly, token budget management, context pruning, and context refresh.
+---
+
+# Context Engineering Workflow (`/context-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **Context Engineering Workflow** is responsible for discovering, filtering, assembling, pruning, and refreshing repository context required by an autonomous AI agent. It ensures the agent operates with exact, highly relevant repository state while staying within model token budgets.
+
+### Responsibilities
+* Context Discovery: Scanning workspace files, rules, skills, workflows, and git logs.
+* Memory Hierarchy Management: Structuring context into core rules, domain guidelines, task context, and transient state.
+* Context Pruning & Compression: Removing irrelevant code, whitespace, and truncated logs to optimize token usage.
+* Token Budget Management: Allocating context windows efficiently across task phases.
+* Context Refresh: Dynamically refreshing stale context during long-running execution loops.
+
+### When to Use
+* Immediately after Prompt Engineering to assemble context for planning or execution.
+* Before major code modification steps to load target file dependencies.
+* Periodically during long-running autonomous loops when context drift occurs.
+
+### When NOT to Use
+* For generating code modifications directly (delegate to Loop Engineering).
+* For running CLI verification commands (delegate to Harness Engineering).
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `ValidatedPrompt` | Text | Yes | Prompt output from Prompt Engineering |
+| `TargetFiles` | Array | No | Specific files targeted for analysis or modification |
+| `TokenBudget` | Number | No | Max token count allowed for context assembly (default: 32,000 tokens) |
+| `MemoryLayers` | Array | No | Specified layers to load (e.g., `["rules", "skills", "code"]`) |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `ContextBundle` | Markdown / JSON | Fully assembled, pruned, and structured context package |
+| `TokenUsageReport` | JSON | Breakdown of token counts per loaded context section |
+| `FileTreeSnapshot` | Text | Relevant workspace directory structure snapshot |
+| `StaleContextAlert` | Boolean / String | Indicator if cached context needs re-reading from disk |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    PE["Prompt Engineering"] --> CE["Context Engineering"]
+    CE --> PL["Planning Engineering"]
+    CE --> LE["Loop Engineering"]
+```
+
+* **Upstream**: Prompt Engineering (provides directives for context selection)
+* **Downstream**: Planning Engineering, Loop Engineering (consume the assembled ContextBundle)
+
+---
+
+## Internal Phases
+
+### Phase 1: Repository Discovery & File Scanning
+* **Objective**: Identify relevant workspace files, documentation, and agent rules.
+* **Actions**:
+  1. Scan `.agent/rules/`, `.agent/skills/`, and `.agent/shared/` for applicable guidelines.
+  2. Locate target implementation files and their direct dependencies (`imports`/`exports`).
+* **Success Criteria**: Complete file list of targeted source files and rules.
+
+### Phase 2: Memory Hierarchy Assembly
+* **Objective**: Structure loaded information by priority level.
+* **Hierarchy Layers**:
+  1. **Layer 0 (Highest)**: Core Safety & System Rules (`.agent/shared/guardrails.md`).
+  2. **Layer 1**: Task Specifications & Acceptance Criteria (`implementation_plan.md`).
+  3. **Layer 2**: Relevant Skills & Workflows (`.agent/workflows/*`).
+  4. **Layer 3**: Target Source Code Files & Tests.
+  5. **Layer 4 (Lowest)**: Historical Transcripts & Search Results.
+* **Success Criteria**: Context ordered strictly by hierarchy priority.
+
+### Phase 3: Pruning & Compression
+* **Objective**: Remove redundant information to minimize token consumption.
+* **Actions**:
+  1. Strip unnecessary comments, duplicate whitespace, and unneeded test fixtures.
+  2. Summarize large documentation files into key actionable bullets.
+* **Success Criteria**: 30-50% reduction in context size with zero loss of critical semantics.
+
+### Phase 4: Token Budget Allocation
+* **Objective**: Ensure assembled bundle fits safely within model limits.
+* **Actions**:
+  1. Calculate total token count of assembled memory layers.
+  2. Truncate lowest priority layers (Layer 4) if total exceeds `TokenBudget`.
+* **Success Criteria**: `TotalTokens <= TokenBudget`.
+
+### Phase 5: Context Refresh (Long-Running Support)
+* **Objective**: Prevent context drift during multi-step execution.
+* **Actions**:
+  1. Re-read modified files from disk after each Loop Engineering step.
+  2. Invalidate stale file representations in memory.
+* **Success Criteria**: Context bundle reflects exact disk state.
+
+---
+
+## Execution Rules
+
+1. **Hierarchy First**: Safety guardrails MUST ALWAYS occupy the highest priority layer in context.
+2. **Relative Paths Only**: File paths inside context bundles MUST use project-relative formatting.
+3. **No Hallucinated Schemas**: File contents MUST be read directly from source files using file inspection tools.
+4. **Token Limit Enforcement**: Context bundles MUST NOT exceed the specified `TokenBudget`.
+
+---
+
+## Guardrails
+
+* **Secret Masking**: Automatically filter out credentials, `.env` values, or API keys from loaded context text.
+* **Sanitization Check**: Ensure no absolute machine paths (`C:\Users\...`) leak into assembled context bundles.
+
+---
+
+## Best Practices
+
+* Inspect authoritative source files directly rather than relying on stale memory summaries.
+* Keep transient log context separate from core rules to preserve token space for reasoning.
+* Use git diffs (`git diff --staged`) to load minimal focused context during reviews.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Context Flooding**: Reading the entire repository codebase into context at once.
+* ❌ **Ignoring Token Limits**: Allowing token usage to exceed 90% of model window capacity.
+* ❌ **Stale Context Persistence**: Re-using file contents cached 10 steps ago after edits have occurred.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[Prompt Directives] --> B[Phase 1: Discover Relevant Files & Rules]
+    B --> C[Phase 2: Assemble Memory Hierarchy L0-L4]
+    C --> D[Phase 3: Prune & Compress Content]
+    D --> E{Phase 4: Check Token Budget}
+    E -- Within Budget --> F[Phase 5: Output Context Bundle]
+    E -- Exceeds Budget --> G[Truncate Layer 4 Context]
+    G --> D
+```
+
+---
+
+## Integration Points
+
+* **Prompt Engineering**: Receives prompt specifications to drive search queries.
+* **Planning Engineering**: Supplies context bundles for feature analysis and roadmap generation.
+* **Loop Engineering**: Periodically refreshed by Context Engineering after file edits.
+
+---
+
+## Extensibility
+
+* **Vector Search / RAG Extension**: Future context engineering modules can integrate semantic search or vector database queries into Phase 1 without changing downstream interfaces.

--- a/.agent/workflows/create-pr.md
+++ b/.agent/workflows/create-pr.md
@@ -2,81 +2,64 @@
 description: Create a Pull Request using GitHub CLI for safe code review workflow
 ---
 
-# Create Pull Request Workflow
+# Create Pull Request Workflow (`/create-pr`)
 
-// turbo-all
+Create and submit a GitHub Pull Request using GitHub CLI (`gh`). This workflow integrates with [PR Engineering](./pr-engineering.md) for automated evidence collection and summary formatting.
+
+---
+
+## 🛡️ Guardrails & Safety Rules (STRICTLY ENFORCED)
+
+> [!CAUTION]
+> **NEVER push directly to `main`**. Always create a feature branch (`feat/*`, `fix/*`) and open a Pull Request.
+
+> [!CAUTION]
+> **NEVER auto-merge a Pull Request**. The agent creates the PR; the human user MUST review and merge it.
+
+> [!IMPORTANT]
+> **Pre-PR Verification Gate**: All tests (`{{TEST_COMMAND}}`) and type checks (`{{TYPE_CHECK_COMMAND}}`) MUST pass cleanly before opening a PR.
+
+> [!IMPORTANT]
+> **Path Sanitization**: PR descriptions and titles MUST NOT contain local absolute paths (`C:\Users\...`).
+
+---
 
 ## Prerequisites
 
-- GitHub CLI (`gh`) is installed and authenticated
-- Working tree is clean (`git status` shows no uncommitted changes for unrelated work)
-- You are on the base branch (e.g., `main`) before creating a new feature branch
+- GitHub CLI (`gh`) is installed and authenticated (`gh auth status`).
+- Active working directory is on a feature branch (not `main`).
+- Unit tests (`cd web && npx vitest run`) and type checks (`cd web && npx tsc --noEmit`) pass cleanly.
+
+---
 
 ## Steps
 
-1. Ensure you are on the latest `main` branch:
+1. **Verify Branch Isolation**:
+   ```powershell
+   git branch --show-current
+   ```
+   *Ensure active branch is NOT `main`.*
 
-```powershell
-git switch main
-git pull origin main
-```
+2. **Run Verification Gate**:
+   ```powershell
+   cd web; npx tsc --noEmit; npx vitest run
+   ```
 
-2. Create a new feature branch with a descriptive name. Use one of these prefixes:
-   - `feat/<description>` — New feature
-   - `fix/<description>` — Bug fix
-   - `docs/<description>` — Documentation changes
-   - `refactor/<description>` — Refactoring
-   - `chore/<description>` — Maintenance tasks
+3. **Stage and Commit Changes (Conventional Commits)**:
+   ```powershell
+   git add <files>
+   git commit -m "<type>(<scope>): <description>"
+   ```
+   *Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`*
 
-```powershell
-git switch -c <type>/<short-description>
-```
+4. **Push Feature Branch to Remote**:
+   ```powershell
+   git push -u origin <branch-name>
+   ```
 
-3. Make your code changes (implement the feature, fix, etc.)
+5. **Create Pull Request via GitHub CLI**:
+   ```powershell
+   gh pr create --base main --title "<type>(<scope>): <description>" --body "## Summary`n<description>`n`n## Test Evidence`n- Unit Tests: Passed`n- Type Check: Passed`n`n## Checklist`n- [x] Code follows project style`n- [x] Self-reviewed`n- [x] Relative paths verified"
+   ```
 
-4. Stage and commit changes using **Conventional Commits** format (English):
-
-```powershell
-git add <files>
-git commit -m "<type>(<scope>): <description>"
-```
-
-Examples:
-
-- `feat(task): add priority filter component`
-- `fix(auth): resolve token refresh race condition`
-- `docs(readme): update setup instructions`
-
-5. Push the branch to the remote:
-
-```powershell
-git push -u origin <branch-name>
-```
-
-6. Create a Pull Request using GitHub CLI:
-
-```powershell
-gh pr create --base main --title "<type>(<scope>): <description>" --body-file .github/pull_request_template.md
-```
-
-If `--body-file` is not suitable (e.g., you want to customize the body), use `--body` instead:
-
-```powershell
-gh pr create --base main --title "<type>(<scope>): <description>" --body "## Summary`nDescribe changes here`n`n## Type of Change`n- [x] Feature`n`n## Checklist`n- [x] Code follows project style`n- [x] Self-reviewed"
-```
-
-7. Notify the user of the PR URL using `notify_user` so they can review it.
-
-## Safety Rules
-
-> [!CAUTION]
-> **NEVER** push directly to `main`. Always create a feature branch and PR.
-
-> [!CAUTION]
-> **NEVER** merge a PR without user approval. The agent creates the PR; the user merges it.
-
-> [!IMPORTANT]
-> Always run `git status` before committing to verify which files will be included.
-
-> [!IMPORTANT]
-> Keep PRs small and focused. One PR per feature/fix/task.
+6. **Notify User**: Present the returned PR URL to the user for review.

--- a/.agent/workflows/harness-engineering.md
+++ b/.agent/workflows/harness-engineering.md
@@ -1,0 +1,172 @@
+---
+description: Reusable harness engineering workflow for executing tests, linting, formatting, type-checking, builds, and security scans in isolated environments.
+---
+
+# Harness Engineering Workflow (`/harness-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **Harness Engineering Workflow** provides a secure, reliable execution environment for running validation commands (tests, type checkers, linters, static analyzers, compilers, and security scanners). It abstracts environment-specific CLI calls using project-level configuration mappings (`.agent/shared/project-config.md`).
+
+### Responsibilities
+* Sandbox & Environment Validation: Verifying prerequisites before executing shell operations.
+* Test Execution: Invoking unit, integration, and E2E test suites (`{{TEST_COMMAND}}`).
+* Static Type & Syntax Analysis: Running canonical type-checkers (`{{TYPE_CHECK_COMMAND}}`) and linters (`{{LINT_COMMAND}}`).
+* Build Verification: Running compilation and production bundle builds (`{{BUILD_COMMAND}}`).
+* Security Scanning: Executing vulnerability scans (`{{SECURITY_SCAN_COMMAND}}`).
+* Execution Isolation & Result Parsing: Capturing exit codes and parsing stdout/stderr into machine-readable reports.
+
+### When to Use
+* Invoked by Loop Engineering to verify implementation steps.
+* Invoked by Verification Engineering to perform quality gate validation.
+* Invoked before creating PRs to ensure full build and test integrity.
+
+### When NOT to Use
+* For generating code edits or modifying repository logic directly.
+* For defining overall task roadmaps or user stories.
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `TargetChecks` | Array | Yes | Suite of checks to run (e.g., `["test", "typecheck", "lint", "build"]`) |
+| `ScopeFiles` | Array | No | Specific files or directories to filter test/lint targets |
+| `CoverageRequired` | Boolean | No | Whether to calculate code coverage (default: `true`) |
+| `EnvironmentOverrides` | Dictionary | No | Environment variables required for execution |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `HarnessResult` | JSON | Aggregate pass/fail status and breakdown of check results |
+| `TestSummary` | JSON | Passed/failed test counts, failed assertion snippets, coverage % |
+| `TypeCheckErrors` | Array | Parsed list of TypeScript / compiler errors with line numbers |
+| `LintErrors` | Array | Parsed list of linter violations |
+| `RawLogs` | Text | Un-truncated console stdout/stderr log output |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    LE["Loop Engineering"] --> HE["Harness Engineering"]
+    VE["Verification Engineering"] --> HE["Harness Engineering"]
+    HE --> PC["Project Config (.agent/shared/project-config.md)"]
+```
+
+* **Upstream**: Loop Engineering, Verification Engineering (request execution of validation checks)
+* **Downstream**: Project Config (provides abstract command mappings: `{{TEST_COMMAND}}`, `{{TYPE_CHECK_COMMAND}}`, etc.)
+
+---
+
+## Internal Phases
+
+### Phase 1: Environment & Prerequisite Validation
+* **Objective**: Confirm execution sandbox and dependencies are clean.
+* **Actions**:
+  1. Verify working directory matches workspace root.
+  2. Check availability of runtime tools (`node`, `npm`, `vitest`, `tsc`).
+* **Success Criteria**: All prerequisite binaries present and responsive.
+
+### Phase 2: Static Analysis & Type Checking
+* **Objective**: Ensure code type safety and syntax correctness.
+* **Actions**:
+  1. Execute `{{TYPE_CHECK_COMMAND}}`.
+  2. Execute `{{LINT_COMMAND}}`.
+* **Success Criteria**: Zero type errors (`0` exit code) and zero critical lint violations.
+
+### Phase 3: Test Execution & Coverage Calculation
+* **Objective**: Verify functional behavior and measure code coverage.
+* **Actions**:
+  1. Execute `{{TEST_COMMAND}}` or `{{TEST_COVERAGE_COMMAND}}`.
+  2. Parse test runner output for failures and coverage metrics.
+* **Success Criteria**: 100% of tests pass; coverage meets `{{COVERAGE_THRESHOLD}}`%.
+
+### Phase 4: Build Compilation Verification
+* **Objective**: Verify project compiles cleanly without bundling errors.
+* **Actions**:
+  1. Execute `{{BUILD_COMMAND}}`.
+* **Success Criteria**: Successful build artifact generation (`0` exit code).
+
+### Phase 5: Security & Vulnerability Scan
+* **Objective**: Check dependencies for known security vulnerabilities.
+* **Actions**:
+  1. Execute `{{SECURITY_SCAN_COMMAND}}`.
+* **Success Criteria**: Zero critical or high severity vulnerability flags.
+
+### Phase 6: Report Aggregation & Machine Output Parsing
+* **Objective**: Format execution findings into machine-readable structured JSON.
+* **Actions**:
+  1. Aggregate outputs into standard `HarnessResult` schema.
+* **Success Criteria**: Machine-readable JSON output emitted to calling workflow.
+
+---
+
+## Execution Rules
+
+1. **Abstract Commands Only**: Harness Engineering MUST execute commands via `.agent/shared/project-config.md` variables.
+2. **Un-truncated Error Logs**: Upon command failure, full error tracebacks MUST be captured for diagnostic analysis.
+3. **No Silent Swallowing**: Non-zero exit codes MUST NEVER be ignored or masked as successful execution.
+4. **Clean Execution Directory**: Commands MUST be executed from the proper relative workspace directory (`./web`, etc.).
+
+---
+
+## Guardrails
+
+* **Timeout Enforcer**: Cap command execution at 5 minutes per verification phase to prevent hangs.
+* **Sandbox Isolation**: Prevent commands from writing files outside the designated workspace bounds.
+* **Mask Secret Variables**: Redact environment secrets from command output before emitting logs.
+
+---
+
+## Best Practices
+
+* Run lightweight static type checks before running heavy integration test suites to fail fast.
+* Focus test execution on modified files during iterative loops, running the full suite only before final PR creation.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Hardcoded CLI Commands**: Hardcoding `npx vitest run` instead of using `{{TEST_COMMAND}}`.
+* ❌ **Masking Failures**: Returning success when tests fail by catching errors silently.
+* ❌ **Ignoring Truncated Tracebacks**: Attempting to fix bugs without fetching full un-truncated error logs.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[Execution Request] --> B[Phase 1: Validate Environment]
+    B --> C[Phase 2: Run Type Check & Lint]
+    C -- Fail --> G[Phase 6: Format Failure Report]
+    C -- Pass --> D[Phase 3: Run Test Suite]
+    D -- Fail --> G
+    D -- Pass --> E[Phase 4: Run Build Verification]
+    E -- Fail --> G
+    E -- Pass --> F[Phase 5: Run Security Scan]
+    F --> H[Phase 6: Emit Aggregate HarnessResult]
+```
+
+---
+
+## Integration Points
+
+* **Loop Engineering**: Called continuously during TDD cycles to check test results.
+* **Verification Engineering**: Called to run full regression tests and quality gate audits.
+* **Project Config**: Serves as the source of truth for command bindings (`{{...}}`).
+
+---
+
+## Extensibility
+
+* **Container / Docker Harness Extension**: Phase 1 can be extended to launch ephemeral Docker containers or VM sandboxes for non-JS/Node environments.

--- a/.agent/workflows/loop-engineering.md
+++ b/.agent/workflows/loop-engineering.md
@@ -1,0 +1,216 @@
+---
+description: Reusable loop engineering workflow for autonomous execution loops, TDD iteration, self-correction, retry strategy, checkpoint management, and context refresh.
+---
+
+# Loop Engineering Workflow (`/loop-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **Loop Engineering Workflow** is the core autonomous execution engine of the agent operating system. It consumes decomposed micro-task queues from Planning Engineering and executes them iteratively using Test-Driven Development (TDD), automated Harness verification, self-correction, git checkpointing, and periodic context refresh.
+
+### Responsibilities
+* Execution Loop Orchestration: Iterating through task queues step-by-step.
+* TDD Cycle Management: Enforcing RED (test first) → GREEN (minimal implementation) → REFACTOR.
+* Self-Correction & Failure Analysis: Diagnosing error tracebacks and applying targeted fixes.
+* Retry Policy Enforcement: Halting via Circuit Breaker if an error fails 3 consecutive retries.
+* Checkpointing & State Management: Creating git commits after each verified step.
+* Context Refresh: Re-reading modified files to maintain exact disk state in memory.
+
+### When to Use
+* For executing feature implementations, bug fixes, or refactoring roadmaps step-by-step.
+* When running multi-step development tasks autonomously after planning approval.
+
+### When NOT to Use
+* Directly on `main` branch.
+* Without prior planning or task decomposition (run Planning Engineering first).
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `MicroTaskQueue` | Array of JSON | Yes | List of XS/S sized micro-tasks from Planning Engineering |
+| `AcceptanceCriteria` | Array | Yes | Testable completion criteria for each micro-task |
+| `MaxTaskRetries` | Number | No | Max consecutive retries for a single task error (default: `3`) |
+| `TotalRetryBudget` | Number | No | Max cumulative retries across the entire loop (default: `5`) |
+| `MaxTasksPerRun` | Number | No | Max micro-tasks executed per single loop run (default: `5`) |
+| `MaxModifiedFilesPerTask` | Number | No | Max files allowed to be edited per task (default: `3`) |
+| `ContextRefreshInterval` | Number | No | Step interval for context refreshing (default: `1 step`) |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `LoopExecutionReport` | Markdown | Comprehensive report of executed tasks, test results, and commits |
+| `CheckpointsLog` | Array of JSON | List of git commit SHAs generated during loop execution |
+| `HaltedStateData` | JSON / Null | Failure diagnosis and error trace if loop was halted by Circuit Breaker |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    PL["Planning Engineering"] --> LE["Loop Engineering"]
+    LE <--> HE["Harness Engineering"]
+    LE <--> CE["Context Engineering"]
+    LE --> VE["Verification Engineering"]
+```
+
+* **Upstream**: Planning Engineering (supplies task queue)
+* **Downstream**: Harness Engineering (invoked for test/type verification), Context Engineering (invoked for context refresh), Verification Engineering (invoked upon loop completion)
+
+---
+
+## Internal Phases
+
+### Phase 1: Pre-Loop Validation & Branch Protection
+* **Objective**: Ensure safe execution environment before file edits.
+* **Actions**:
+  1. Verify active branch is NOT `main`.
+  2. Confirm working tree is clean or has stash checkpoint.
+* **Success Criteria**: Active branch matches `feat/*` or `fix/*`.
+
+### Phase 2: Task Queue Initialization & State Setup
+* **Objective**: Load micro-tasks and initialize cost/retry state trackers.
+* **Actions**:
+  1. Initialize `TaskQueue`, `CompletedTasks`.
+  2. Initialize state counters: `TaskRetryCount = 0`, `TotalRetryCount = 0`, `ExecutedTaskCount = 0`.
+* **Success Criteria**: Queue loaded; counters zeroed; budget limits registered.
+
+### Phase 3: Iterative TDD & Implementation Loop
+For each micro-task in `TaskQueue` (up to `MaxTasksPerRun` limit):
+
+1. **Step A: High-Risk Action & Scope Pre-Check**
+   - Check task scope: Ensure target files count <= `MaxModifiedFilesPerTask` (default 3 files).
+   - Check destructive operations: If task requires deleting core files/directories or DB resets, HALT and trigger **Approval Hook** ([guardrails.md §5](file://./.agent/shared/guardrails.md#L46-L53)).
+2. **Step B: TDD RED (Write/Update Test)**
+   - Write failing unit/integration test covering expected behavior.
+   - Invoke Harness Engineering to verify test **FAILS** for the right reason.
+3. **Step C: TDD GREEN (Minimal Implementation)**
+   - Write minimal production code required to satisfy the test.
+   - Invoke Harness Engineering to verify test **PASSES**.
+4. **Step D: TDD REFACTOR & Re-Verification**
+   - Clean code, improve names, ensure immutability while keeping tests green.
+   - Re-invoke Harness Engineering (`TargetChecks: ["test", "typecheck"]`) to verify refactoring introduced zero regressions.
+
+### Phase 4: Automated Verification & Diagnostic Catch
+* **Objective**: Validate correctness via Harness Engineering and update state counters.
+* **Actions**:
+  1. Invoke Harness Engineering (`TargetChecks: ["test", "typecheck"]`).
+  2. If PASS: Reset `TaskRetryCount = 0`, increment `ExecutedTaskCount++`, proceed to Phase 6.
+  3. If FAIL: Increment `TaskRetryCount++` AND `TotalRetryCount++`, proceed to Phase 5.
+
+### Phase 5: Self-Correction & Dual Circuit Breaker Logic
+* **Objective**: Diagnose failure logs and apply targeted fixes or trigger circuit breaker.
+* **Actions**:
+  1. Inspect un-truncated stdout/stderr error logs from Harness.
+  2. Formulate root-cause hypothesis (never mask symptoms or delete tests).
+  3. **Circuit Breaker Evaluation**:
+     - If `TaskRetryCount <= MaxTaskRetries` AND `TotalRetryCount <= TotalRetryBudget`: Apply targeted fix and return to Phase 3.
+     - If `TaskRetryCount > MaxTaskRetries` OR `TotalRetryCount > TotalRetryBudget`: **HALT EXECUTION IMMEDIATELY**, emit `HaltedStateData`, and request human intervention.
+
+### Phase 6: Checkpointing & State Commit
+* **Objective**: Save progress securely.
+* **Actions**:
+  1. Stage changed files (`git add <files>`).
+  2. Commit using Conventional Commits (`git commit -m "<type>(<scope>): <description>"`).
+* **Success Criteria**: Clean git status; new commit SHA logged.
+
+### Phase 7: Targeted Context Refresh & Token Budget Control
+* **Objective**: Refresh memory efficiently without consuming excessive tokens.
+* **Actions**:
+  1. Invoke Context Engineering to re-read **ONLY modified files** from Phase 6 checkpoint.
+  2. Prune obsolete stack trace logs from memory to maintain token budget.
+* **Success Criteria**: Agent context updated with exact disk state at minimal token cost.
+
+### Phase 8: Loop Completion & Handoff
+* **Objective**: Transition to Verification Engineering when queue is empty or `MaxTasksPerRun` limit reached.
+* **Actions**:
+  1. Check queue completion or run limits (`ExecutedTaskCount >= MaxTasksPerRun`).
+  2. Emit `LoopExecutionReport` to Verification Engineering or User.
+
+---
+
+## Execution Rules
+
+1. **Never Skip RED Phase**: Tests MUST be written and verified failing before writing business logic.
+2. **No Superficial Patches**: NEVER fix errors by swallowing exceptions, deleting failing assertions, or disabling type checks.
+3. **Strict Retry Hard Stop**: STOP immediately when single-task retries fail 3 times OR cumulative loop retries reach 5.
+4. **Scope & Task Caps**: STOP loop execution after 5 micro-tasks or if a single task touches > 3 files.
+5. **Clean Checkpoints Only**: Commits MUST NOT be created if unit tests or type checks are failing.
+
+---
+
+## Guardrails
+
+* **Branch Gate**: Halt if active branch is `main`.
+* **Dual Circuit Breaker**: Hard limit of 3 retries per task failure and 5 cumulative retries per execution session.
+* **Cost & Scope Limit**: Cap continuous execution at 5 tasks and 3 files per task to prevent token/cost inflation.
+* **Approval Hook**: Halt and request user approval before executing destructive actions (directory removal, DB resets).
+* **Rollback Command**: In the event of a circuit breaker trip, provide `git reset --hard <last-checkpoint-sha>` instructions to user.
+
+---
+
+## Best Practices
+
+* Keep micro-tasks small (XS/S) so each iteration takes < 5 minutes and modifies <= 3 files.
+* Run focused tests during iteration loops, saving full suite execution for final completion.
+* Prune large test outputs from agent memory between checkpoints to optimize token usage.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Infinite Fixing Loops**: Trying 10+ random changes without diagnosing root causes.
+* ❌ **Token Waste Batching**: Editing 5+ files or running 10+ tasks in a single un-checkpointed loop.
+* ❌ **Test Masking**: Modifying test expectations to force a broken implementation to pass.
+* ❌ **Memory Bloat**: Retaining thousands of lines of raw test stdout in prompt history.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[MicroTaskQueue Input] --> B[Phase 1: Verify Feature Branch]
+    B --> C[Phase 2: Initialize Queue & State Counters]
+    C --> D[Pick Next Micro-Task]
+    D --> ScopeCheck{Task Scope & Risk Check}
+    ScopeCheck -- Destructive / Scope > 3 Files --> Approval[Trigger Approval Hook & HALT]
+    ScopeCheck -- OK --> E[Step 3B: TDD RED - Write Failing Test]
+    E --> F[Step 3C: TDD GREEN - Minimal Code]
+    F --> REFACTOR[Step 3D: TDD REFACTOR & Re-Verify]
+    REFACTOR --> G{Phase 4: Run Harness Verification}
+    G -- Pass --> H[Phase 6: Create Git Checkpoint Commit]
+    H --> I[Phase 7: Refresh Targeted Context Memory]
+    I --> J{Executed Tasks < MaxTasksPerRun?}
+    J -- Yes --> D
+    J -- No / Queue Empty --> K[Phase 8: Handoff to Verification / User]
+    
+    G -- Fail --> L{Phase 5: Check Dual Circuit Breaker}
+    L -- TaskCount <= 3 AND TotalCount <= 5 --> M[Analyze Logs & Apply Targeted Fix]
+    M --> F
+    L -- TaskCount > 3 OR TotalCount > 5 --> N[HALT: Dual Circuit Breaker Tripped]
+```
+
+---
+
+## Integration Points
+
+* **Planning Engineering**: Source of structured task queues.
+* **Harness Engineering**: Invoked after every code edit to execute tests/type-checks.
+* **Context Engineering**: Invoked after checkpoints to refresh disk state in memory.
+* **Verification Engineering**: Receives completed codebase for final quality gate review.
+
+---
+
+## Extensibility
+
+* **Parallel Task Execution Subagents**: Future extensions can spawn parallel sub-agent loops for non-overlapping micro-tasks across decoupled subdirectories.

--- a/.agent/workflows/planning-engineering.md
+++ b/.agent/workflows/planning-engineering.md
@@ -1,0 +1,172 @@
+---
+description: Reusable planning engineering workflow for requirement analysis, task decomposition, dependency graphing, risk assessment, and implementation roadmapping.
+---
+
+# Planning Engineering Workflow (`/planning-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **Planning Engineering Workflow** converts high-level feature requests, user stories, or bug reports into structured, actionable implementation plans. It decomposes complex engineering goals into small, testable micro-tasks (Size **XS** or **S**) and maps technical risks before code modification begins.
+
+### Responsibilities
+* Requirement Analysis & Scope Definition: Clarifying functional goals and non-functional constraints.
+* Architectural & Dependency Graph Mapping: Identifying files, modules, and API boundaries affected.
+* Task Breakdown & Micro-Task Sizing: Decomposing tasks into XS (< 1h) or S (1-2h) work units.
+* Technical Risk Assessment: Identifying security vulnerabilities, breaking changes, and state side-effects.
+* Implementation Roadmap Generation: Producing formal `implementation_plan.md` artifacts.
+* User Approval Protocol: Halting execution to present proposed plans for human consent.
+
+### When to Use
+* Whenever starting a new feature, complex refactoring, or multi-step bug fix.
+* When a user request involves ambiguous requirements, architectural changes, or risk.
+
+### When NOT to Use
+* For trivial one-off tweaks (e.g., fixing a typo, updating a single comment).
+* For executing code implementation directly (delegate to Loop Engineering).
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `ContextBundle` | Object | Yes | Assembled context bundle from Context Engineering |
+| `UserRequest` | String | Yes | Feature specification or issue description |
+| `ArchitectureRules` | Array | No | Project architectural guidelines and coding standards |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `ImplementationPlan` | Markdown Artifact | Formal `implementation_plan.md` document with step-by-step roadmap |
+| `MicroTaskQueue` | Array of JSON | Structured list of XS/S micro-tasks ready for Loop Engineering |
+| `DependencyGraph` | Mermaid / Text | File and component dependency relationship map |
+| `RiskAssessmentReport` | Markdown | Identified technical risks, security constraints, and mitigation strategies |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    CE["Context Engineering"] --> PL["Planning Engineering"]
+    PL --> LE["Loop Engineering"]
+    PL --> UserApproval["Human User Approval"]
+```
+
+* **Upstream**: Context Engineering (supplies workspace files, rules, and token-budgeted context)
+* **Downstream**: Loop Engineering (receives `MicroTaskQueue` for iterative implementation)
+
+---
+
+## Internal Phases
+
+### Phase 1: Requirement Analysis & Scope Definition
+* **Objective**: Define exact functional targets and eliminate ambiguity.
+* **Actions**:
+  1. Parse `UserRequest` against project architecture rules.
+  2. Identify ambiguities; formulate targeted clarification questions if essential.
+* **Success Criteria**: Clear problem statement and objective summary.
+
+### Phase 2: Architectural Mapping & Dependency Graphing
+* **Objective**: Trace files and components affected by proposed changes.
+* **Actions**:
+  1. Map module dependencies, imported types, and API endpoint contracts.
+  2. Generate visual component dependency graph.
+* **Success Criteria**: Complete list of files to create, modify, or delete.
+
+### Phase 3: Task Decomposition & Micro-Task Sizing
+* **Objective**: Break goals down into small, low-risk execution units.
+* **Sizing Standards**:
+  - **XS (< 1h)**: Single function, simple utility, unit test creation.
+  - **S (1-2h)**: Component scaffold, API route implementation, state model update.
+  - **M (Half day)**: *Recommend splitting into XS/S tasks*.
+  - **L (1 day+)**: *MUST be split into multiple child tasks*.
+* **Success Criteria**: 100% of micro-tasks sized XS or S.
+
+### Phase 4: Risk Analysis & Security Impact Assessment
+* **Objective**: Identify potential security risks, breaking changes, and failure modes.
+* **Actions**:
+  1. Evaluate XSS, injection, authentication, and data privacy impact.
+  2. Verify paths use relative formatting (`./web/...`) to prevent path leaks.
+* **Success Criteria**: Risk mitigation strategy defined for all identified risks.
+
+### Phase 5: Implementation Roadmap & Artifact Generation
+* **Objective**: Write formal `implementation_plan.md` artifact.
+* **Actions**:
+  1. Create document using standard implementation plan template.
+  2. Set `ArtifactMetadata` (`RequestFeedback: true`, `UserFacing: true`).
+* **Success Criteria**: Validated `implementation_plan.md` artifact saved to workspace.
+
+### Phase 6: Human-in-the-Loop Approval Gate
+* **Objective**: Obtain explicit user authorization before code editing begins.
+* **Actions**:
+  1. Present plan proposal template to user.
+  2. **HALT execution** until user approves (`Yes` / `Proceed`).
+* **Success Criteria**: Explicit user approval received.
+
+---
+
+## Execution Rules
+
+1. **Strict Task Sizing**: Plans MUST NOT contain tasks sized M or L; all tasks MUST be decomposed to XS or S.
+2. **Approval Mandatory**: Code modifications MUST NOT begin until the plan is explicitly approved by the user.
+3. **Relative Paths Only**: File targets in implementation plans MUST use project-relative paths.
+4. **No Hidden Assumptions**: Unknown schema details MUST be investigated using Context Engineering before planning.
+
+---
+
+## Guardrails
+
+* **Branch Gate**: Verify target branch is a feature branch (`feat/*`, `fix/*`) before outputting plan.
+* **No Direct Edit Phase**: Planning Engineering MUST NOT write or modify application source code directly.
+
+---
+
+## Best Practices
+
+* Use GitHub alerts (`> [!IMPORTANT]`, `> [!WARNING]`) to highlight key design decisions or breaking changes.
+* Order micro-tasks logically: interface/type definitions first, test scaffolding second, implementation third.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Monolithic Tasks**: Creating a single task "Build user authentication feature".
+* ❌ **Bypassing User Approval**: Writing implementation code before plan approval.
+* ❌ **Speculative Planning**: Guessing API endpoint schemas without verifying authoritative source files.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[Context Bundle Input] --> B[Phase 1: Analyze Requirements]
+    B --> C[Phase 2: Map Architectural Dependencies]
+    C --> D[Phase 3: Decompose Tasks into XS/S Sizing]
+    D --> E[Phase 4: Risk & Security Assessment]
+    E --> F[Phase 5: Generate implementation_plan.md]
+    F --> G{Phase 6: User Approval Gate}
+    G -- Approved --> H[Output MicroTaskQueue to Loop Engineering]
+    G -- Rejection / Modify --> B
+```
+
+---
+
+## Integration Points
+
+* **Context Engineering**: Supplies repository structure and dependency context for planning.
+* **Loop Engineering**: Consumes `MicroTaskQueue` to drive step-by-step execution.
+* **Verification Engineering**: Uses plan acceptance criteria to evaluate quality gates.
+
+---
+
+## Extensibility
+
+* **WBS / Issue Exporter**: Can be extended to automatically generate individual GitHub Issues for each decomposed micro-task using GitHub CLI (`gh issue create`).

--- a/.agent/workflows/pr-engineering.md
+++ b/.agent/workflows/pr-engineering.md
@@ -1,0 +1,175 @@
+---
+description: Reusable PR engineering workflow for change summaries, conventional commits, release notes, reviewer checklists, test evidence collection, and PR creation.
+---
+
+# PR Engineering Workflow (`/pr-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **PR Engineering Workflow** automates the packaging, summarization, evidence collation, and opening of GitHub Pull Requests. It ensures that every PR submitted by an autonomous AI agent is well-structured, contains verifiable test evidence, adheres to Conventional Commits, and complies with safety policies.
+
+### Responsibilities
+* Commit History Analysis: Analyzing full branch commit history (not just latest commit).
+* Change Summary & Release Notes Drafting: Writing clear, human-readable explanations of changes.
+* Conventional Commit Enforcement: Validating PR titles and commit formats (`<type>(<scope>): <description>`).
+* Test Evidence Collation: Embedding unit test, type-check, and coverage verification output into PR bodies.
+* Reviewer Checklist & Risk Summary: Providing automated checklist and risk assessment for human reviewers.
+* PR Creation: Executing `gh pr create` with validated parameters.
+
+### When to Use
+* Upon successful completion of Verification Engineering (`QualityGateVerdict` = `APPROVE` or `WARNING`).
+* When ready to submit feature branches for human code review.
+
+### When NOT to Use
+* If Verification Engineering issued a `BLOCK` verdict (resolve issues first).
+* For pushing directly to `main` branch (NEVER push directly to main).
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `QualityGateVerdict` | Enum | Yes | Must be `APPROVE` or `WARNING` from Verification Engineering |
+| `VerificationReport` | Object | Yes | Detailed verification metrics, test coverage, and security audit |
+| `TargetBaseBranch` | String | No | Target base branch for PR (default: `main`) |
+| `PRTemplatePath` | String | No | Path to PR template (default: `.github/pull_request_template.md`) |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `PullRequestURL` | String | Web URL of the newly created GitHub Pull Request |
+| `PullRequestBody` | Markdown | Rendered PR body containing summary, evidence, and checklist |
+| `PRSubmissionReport` | JSON | Machine-readable metadata of submitted PR (PR #, branch, status) |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    VE["Verification Engineering"] --> PRE["PR Engineering"]
+    PRE --> GitHubCLI["GitHub CLI (gh)"]
+    PRE --> User["Human Developer Reviewer"]
+```
+
+* **Upstream**: Verification Engineering (provides `QualityGateVerdict` and `VerificationReport`)
+* **Downstream**: GitHub CLI (`gh`), Human Developer (notified to review PR)
+
+---
+
+## Internal Phases
+
+### Phase 1: Pre-Submission Verification Check
+* **Objective**: Confirm quality gate status before creating PR.
+* **Actions**:
+  1. Check `QualityGateVerdict`. If `BLOCK`, halt immediately.
+  2. Verify working tree status and active branch.
+* **Success Criteria**: Verdict is `APPROVE` or `WARNING`; active branch is `feat/*`, `fix/*`, etc.
+
+### Phase 2: Commit History & Change Analysis
+* **Objective**: Aggregate full history of changes across the branch.
+* **Actions**:
+  1. Fetch commit history: `git log main..HEAD --oneline`.
+  2. Fetch changed file list: `git diff --name-only main...HEAD`.
+* **Success Criteria**: Complete list of commits and modified files.
+
+### Phase 3: Change Summary & Conventional Title Formatting
+* **Objective**: Format title and body using Conventional Commits standard.
+* **Format Rules**: `<type>(<scope>): <short description>`
+  - Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+* **Success Criteria**: Validated Conventional Commit title string.
+
+### Phase 4: Test Evidence Collation
+* **Objective**: Embed verified test evidence into PR description.
+* **Actions**:
+  1. Attach test pass counts, type check status, and coverage metrics.
+  2. Format evidence table in Markdown.
+* **Success Criteria**: Markdown evidence table embedded in PR body.
+
+### Phase 5: Reviewer Checklist & Risk Summary Assembly
+* **Objective**: Give human reviewers explicit review guidance.
+* **Actions**:
+  1. Assemble checklist items (Security checked, tests passing, relative paths verified).
+  2. Highlight any potential breaking changes or risks.
+* **Success Criteria**: Complete reviewer checklist section in PR body.
+
+### Phase 6: Pull Request Execution via GitHub CLI
+* **Objective**: Submit PR to GitHub remote.
+* **Actions**:
+  1. Push feature branch to remote: `git push -u origin <branch-name>`.
+  2. Execute `gh pr create --base main --title "..." --body "..."`.
+* **Success Criteria**: `gh` CLI returns valid PR URL (e.g., `https://github.com/.../pull/98`).
+
+### Phase 7: User Notification & Handover
+* **Objective**: Notify user of PR submission.
+* **Actions**:
+  1. Present PR URL and summary report to user in chat.
+  2. **HALT**: Wait for human review and merge approval.
+* **Success Criteria**: User notified with hyperlinked PR URL.
+
+---
+
+## Execution Rules
+
+1. **Never Push to Main**: PR Engineering MUST NEVER push directly to `main` or merge PRs autonomously.
+2. **Quality Gate Prerequisite**: PR creation MUST NOT proceed if Verification Engineering issued a `BLOCK` verdict.
+3. **No Machine Path Leaks**: PR title, body, and commits MUST NOT contain absolute local file paths.
+4. **User Merges PR**: The agent creates the PR; the human developer reviews and merges it.
+
+---
+
+## Guardrails
+
+* **Verification Gate**: Strictly block PR execution if `QualityGateVerdict` == `BLOCK`.
+* **Merge Gate**: Agent MUST NOT run `gh pr merge` without explicit user instruction.
+
+---
+
+## Best Practices
+
+* Keep PRs small and focused (One feature/fix per PR).
+* Use GitHub PR templates (`.github/pull_request_template.md`) when available.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Auto-Merging PRs**: Automatically merging PRs into `main` without human review.
+* ❌ **Vague PR Titles**: Creating PRs titled "Updates", "Fixes", or "WIP".
+* ❌ **Missing Evidence**: Opening PRs without including test pass/fail results and coverage data.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[Verification Report Input] --> B{Phase 1: Check Quality Gate Verdict}
+    B -- Verdict == BLOCK --> C[HALT: Blocked by Quality Gate]
+    B -- Verdict == APPROVE / WARNING --> D[Phase 2: Analyze Commit History & Diff]
+    D --> E[Phase 3: Format Conventional Commit Title]
+    E --> F[Phase 4: Collate Test Evidence & Coverage]
+    F --> G[Phase 5: Assemble Reviewer Checklist & Risks]
+    G --> H[Phase 6: Push Branch & Run gh pr create]
+    H --> I[Phase 7: Notify User with PR URL]
+```
+
+---
+
+## Integration Points
+
+* **Verification Engineering**: Provides input quality gate verdict and evidence metrics.
+* **GitHub CLI (`gh`)**: System tool invoked to execute remote PR creation.
+
+---
+
+## Extensibility
+
+* **Automated CI/CD Trigger Integration**: Phase 7 can be extended to monitor GitHub Actions CI pipeline status after PR creation and report build results back to the user.

--- a/.agent/workflows/prompt-engineering.md
+++ b/.agent/workflows/prompt-engineering.md
@@ -1,0 +1,160 @@
+---
+description: Reusable prompt engineering workflow for instruction design, role definition, output contracts, prompt validation, and template optimization.
+---
+
+# Prompt Engineering Workflow (`/prompt-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **Prompt Engineering Workflow** is responsible for designing, structuring, validating, and optimizing agent instructions and output contracts. It converts raw, ambiguous user intentions into well-formatted, deterministic prompt specifications that downstream workflows can execute reliably.
+
+### Responsibilities
+* Persona & Role Definition: Establishing strict agent behaviors and domain expertise.
+* Output Contract Engineering: Defining machine-readable JSON/Markdown response schemas.
+* Reusable Prompt Templates: Managing modular template placeholders (`{{VARIABLE}}`).
+* Prompt Validation & Verification: Pre-checking prompt clarity, completeness, and safety constraints.
+* Prompt Optimization: Iteratively refining prompts based on execution feedback.
+
+### When to Use
+* Before launching complex autonomous multi-step operations.
+* When defining new agent capabilities, workflows, or slash-commands.
+* When agent outputs fail downstream parsing or exhibit non-deterministic behavior.
+
+### When NOT to Use
+* For trivial one-liner commands or direct user questions that require immediate answers.
+* For actual code implementation, testing, or git operations (delegate to downstream workflows).
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `RawGoal` | String | Yes | Raw user request or high-level feature goal |
+| `TargetRole` | String | No | Specialized agent role (e.g., Security Auditor, Frontend Engineer) |
+| `OutputContractSchema` | Object | No | Expected JSON/Markdown response structure |
+| `ContextVariables` | Dictionary | No | Key-value pairs for prompt template placeholders |
+| `SafetyConstraints` | Array | No | Specific constraints or guardrails to enforce in the prompt |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `ValidatedPrompt` | Markdown / Text | Structured, production-ready system/user prompt |
+| `OutputSchemaDefinition` | JSON Schema / Markdown | Machine-readable contract for expected output |
+| `TemplateVariableMap` | JSON | Validated variable bindings used in prompt |
+| `PromptValidationReport` | Markdown | Completeness and ambiguity assessment report |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    UserReq["User Input"] --> PE["Prompt Engineering"]
+    PE --> CE["Context Engineering"]
+    PE --> PL["Planning Engineering"]
+```
+
+* **Upstream**: User Request, System Capabilities Specification
+* **Downstream**: Context Engineering (loads context based on prompt directives), Planning Engineering (uses prompt contract to generate roadmaps)
+
+---
+
+## Internal Phases
+
+### Phase 1: Persona & Role Definition
+* **Objective**: Establish precise domain identity, capabilities, and system boundaries.
+* **Actions**:
+  1. Define system role, experience level, and operational domain.
+  2. Specify communication language and tone rules.
+  3. Set boundary conditions (what the agent MUST and MUST NOT do).
+* **Success Criteria**: Clear role statement with explicit constraints.
+
+### Phase 2: Instruction & Output Contract Design
+* **Objective**: Structure deterministic execution steps and response formats.
+* **Actions**:
+  1. Translate goals into unambiguous, step-by-step imperative directives.
+  2. Define strict output contracts (e.g., Markdown template, JSON schema).
+  3. Include error reporting formats for failure handling.
+* **Success Criteria**: Machine-parsable output schema definition.
+
+### Phase 3: Template & Placeholder Binding
+* **Objective**: Parameterize instructions for vendor-neutral portability.
+* **Actions**:
+  1. Replace project-specific commands with template variables (`{{TEST_COMMAND}}`, etc.).
+  2. Bind template variables using `.agent/shared/project-config.md`.
+* **Success Criteria**: Fully bound prompt free of unresolved placeholders.
+
+### Phase 4: Prompt Validation & Dry Run
+* **Objective**: Verify prompt against quality criteria before execution.
+* **Actions**:
+  1. Validate against completeness checklist (No missing context, no ambiguous terms).
+  2. Check for security/safety constraint inclusion.
+* **Success Criteria**: Pass 100% of prompt validation checks.
+
+---
+
+## Execution Rules
+
+1. **Explicit Schema Enforcement**: Every generated prompt MUST specify an exact output format contract.
+2. **No Ambiguous Instructions**: Directives MUST use clear, actionable verbs (e.g., "Extract...", "Validate...", "Generate...").
+3. **Template Neutrality**: Prompts MUST use template placeholders (`{{...}}`) for environment-dependent commands.
+4. **Zero Assumptions**: Prompts MUST explicitly state default fallback behaviors when inputs are missing.
+
+---
+
+## Guardrails
+
+* **Constraint Check**: Ensure prompt explicitly includes branch protection (`NEVER push to main`) and retry limits (`max 3 retries`).
+* **Path Sanitization Directive**: Prompt MUST instruct the agent to use project-relative paths.
+* **Secret Leakage Prevention**: System prompts MUST instruct the agent to mask credentials.
+
+---
+
+## Best Practices
+
+* Use clear markdown section headers (`#`, `##`, `###`) to separate instructions, examples, and rules.
+* Provide positive and negative examples (Few-shot prompting) for complex output contracts.
+* Keep system prompts under 500 lines; move extensive reference data to external docs.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Vague Goals**: "Improve the code quality" (Use: "Refactor functions over 50 lines into modular helpers").
+* ❌ **Unstructured Outputs**: Asking for conversational text without a structured template or schema.
+* ❌ **Hardcoded Machine Paths**: Including `C:\Users\...` in prompt templates.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[Raw Goal Input] --> B[Phase 1: Define Role & Boundaries]
+    B --> C[Phase 2: Design Directives & Output Contract]
+    C --> D[Phase 3: Bind Template Variables]
+    D --> E{Phase 4: Validate Prompt}
+    E -- Pass --> F[Validated Production Prompt Output]
+    E -- Fail --> C
+```
+
+---
+
+## Integration Points
+
+* **Context Engineering**: Receives `ValidatedPrompt` to determine which repository files and memory artifacts to load.
+* **Planning Engineering**: Uses `OutputSchemaDefinition` to format milestone roadmaps.
+* **Loop Engineering**: Executes prompts within the iterative loop.
+
+---
+
+## Extensibility
+
+* **Custom Prompt Modules**: Future agents can extend this workflow by adding specialized domain templates (e.g., Security Audit Prompt Module, Performance Optimization Prompt Module) in subdirectories.

--- a/.agent/workflows/tdd.md
+++ b/.agent/workflows/tdd.md
@@ -1,74 +1,54 @@
 ---
-description: Enforce test-driven development workflow. Scaffold interfaces, generate tests FIRST, then implement minimal code to pass. Ensure 80%+ coverage.
+description: Enforce Test-Driven Development (TDD) workflow. Scaffold interfaces, write failing tests FIRST, implement minimal code to pass, and verify 80%+ coverage.
 ---
 
-This workflow invokes the **tdd-guide** skill to enforce test-driven development methodology on My Roadmap.
+# Test-Driven Development Workflow (`/tdd`)
 
-## What This Workflow Does
-1. **Scaffold Interfaces** - Define types/interfaces first
-2. **Generate Tests First** - Write failing tests (RED)
-3. **Implement Minimal Code** - Write just enough to pass (GREEN)
-4. **Refactor** - Improve code while keeping tests green (REFACTOR)
-5. **Verify Coverage** - Ensure 80%+ test coverage
+Enforces Test-Driven Development (TDD) methodology. This workflow delegates test execution to [Harness Engineering](./harness-engineering.md) and uses abstract commands from [project-config.md](../shared/project-config.md).
 
-## When to Use
-Use `/tdd` when:
-- Implementing new features
-- Adding new functions/components
-- Fixing bugs (write test that reproduces bug first)
-- Refactoring existing code
-- Building critical business logic
+---
 
-## How It Works
-The tdd-guide skill will:
+## 🛡️ Guardrails & Safety Rules (STRICTLY ENFORCED)
 
-1. **Define interfaces** for inputs/outputs
-2. **Write tests that will FAIL** (because code doesn't exist yet)
-3. **Run tests** and verify they fail for the right reason (`cd web && npx vitest run`)
-4. **Write minimal implementation** to make tests pass
-5. **Run tests** and verify they pass (`cd web && npx vitest run`)
-6. **Refactor** code while keeping tests green
-7. **Check coverage** (`cd web && npx vitest run --coverage`) and add more tests if below 80%
+> [!CAUTION]
+> **NEVER skip the RED phase**. Implementation code written before tests fail will be rejected.
 
-## TDD Cycle
-```
-RED → GREEN → REFACTOR → REPEAT
+> [!CAUTION]
+> **Circuit Breaker**: If a test fails to pass after **3 consecutive implementation attempts**, HALT execution, revert to last checkpoint (`git checkout -- .`), and request human intervention.
 
-RED:      Write a failing test
-GREEN:    Write minimal code to pass
-REFACTOR: Improve code, keep tests passing
-REPEAT:   Next feature/scenario
+> [!IMPORTANT]
+> **Branch Gate**: Ensure you are on a dedicated feature branch (`feat/*`, `fix/*`) before writing code or tests.
+
+---
+
+## TDD Cycle Phases
+
+```mermaid
+graph LR
+    RED["1. RED: Write Failing Test"] --> VerifyFail["Verify Test FAILS"]
+    VerifyFail --> GREEN["2. GREEN: Minimal Code"]
+    GREEN --> VerifyPass["Verify Test PASSES"]
+    VerifyPass --> REFACTOR["3. REFACTOR: Clean Code"]
+    REFACTOR --> CoverageCheck["Verify Coverage >= 80%"]
 ```
 
-## TDD Best Practices
-**DO:**
-- PASS: Write the test FIRST, before any implementation
-- PASS: Run tests and verify they FAIL before implementing
-- PASS: Write minimal code to make tests pass
-- PASS: Refactor only after tests are green
-- PASS: Add edge cases and error scenarios
-- PASS: Aim for 80%+ coverage (100% for authentication logic)
+---
 
-**DON'T:**
-- FAIL: Write implementation before tests
-- FAIL: Skip running tests after each change
-- FAIL: Write too much code at once
-- FAIL: Ignore failing tests
-- FAIL: Test implementation details (test behavior)
+## Execution Steps
 
-## Coverage Requirements
-- **80% minimum** for all code
-- **100% required** for:
-  - Financial calculations
-  - Authentication logic
-  - Security-critical code
-  - Core business logic
+1. **Scaffold Interfaces / Types**: Define TypeScript input/output contracts.
+2. **Write Failing Test (RED)**: Write unit/integration test describing expected behavior.
+3. **Verify Failure**: Run test command (`{{TEST_COMMAND}}` -> `cd web && npx vitest run`) and verify it **FAILS**.
+4. **Minimal Implementation (GREEN)**: Write ONLY enough production code to make the test pass.
+5. **Verify Pass**: Run `{{TEST_COMMAND}}` and verify it **PASSES**.
+6. **Refactor**: Clean code, improve names, ensure immutability while keeping tests green.
+7. **Verify Coverage**: Run `{{TEST_COVERAGE_COMMAND}}` (`cd web && npx vitest run --coverage`).
+   - Standard code: **80%+ minimum coverage**.
+   - Authentication / Security logic: **100% required coverage**.
 
-## Important Notes
-**MANDATORY**: Tests must be written BEFORE implementation. The TDD cycle is:
+---
 
-1. **RED** - Write failing test
-2. **GREEN** - Implement to pass
-3. **REFACTOR** - Improve code
+## Coverage Requirements & Thresholds
 
-Never skip the RED phase. Never write code before tests.
+- Standard components/utilities: `{{COVERAGE_THRESHOLD}}`% (`80%`) minimum.
+- Authentication & security logic: `{{CRITICAL_COVERAGE_THRESHOLD}}`% (`100%`) required.

--- a/.agent/workflows/verification-engineering.md
+++ b/.agent/workflows/verification-engineering.md
@@ -1,0 +1,176 @@
+---
+description: Reusable verification engineering workflow for quality gates, architecture review, security audit, performance check, and acceptance verification.
+---
+
+# Verification Engineering Workflow (`/verification-engineering`)
+
+---
+
+## Overview
+
+### Purpose
+The **Verification Engineering Workflow** acts as the final automated quality gate before code changes are packaged into Pull Requests. It performs comprehensive static analysis, architectural compliance checks, security audits, performance evaluations, and regression testing to ensure high software quality and prevent security flaws or technical debt from entering the repository.
+
+### Responsibilities
+* Full Regression Verification: Invoking Harness Engineering to run complete test suites and coverage reports.
+* Architecture & Coupling Review: Checking file length (< 800 lines), function length (< 50 lines), and nesting depth (< 4 levels).
+* Coding Standards Compliance: Enforcing immutability, error handling, and type safety rules.
+* Security Vulnerability Audit: Scanning for hardcoded secrets, XSS, injection, CSRF, and path leaks.
+* Quality Gate Decisioning: Issuing formal verdict (APPROVE, WARNING, or BLOCK).
+
+### When to Use
+* Upon completion of Loop Engineering before invoking PR Engineering.
+* During automated pre-PR code review workflows (`/code-review`).
+
+### When NOT to Use
+* For generating initial implementation code (delegate to Loop Engineering).
+* For creating pull requests directly (delegate to PR Engineering).
+
+---
+
+## Inputs
+
+| Input Parameter | Type | Required | Description |
+|:---|:---|:---:|:---|
+| `LoopExecutionReport` | Object | Yes | Summary of completed tasks and modified files from Loop Engineering |
+| `AcceptanceCriteria` | Array | Yes | Target criteria to verify against implementation |
+| `SecurityPolicies` | Array | No | Specific security requirements (`.agent/rules/security.md`) |
+| `QualityThresholds` | Dictionary | No | Custom coverage or quality thresholds |
+
+---
+
+## Outputs
+
+| Output Parameter | Format | Description |
+|:---|:---|:---|
+| `QualityGateVerdict` | Enum | Final decision: `APPROVE`, `WARNING`, or `BLOCK` |
+| `VerificationReport` | Markdown | Comprehensive evaluation report categorizing issues by severity |
+| `SecurityAuditReport` | JSON | Findings for hardcoded secrets, injection, XSS, and authorization |
+| `RegressionTestSummary` | JSON | Full suite test execution and coverage percentage results |
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    LE["Loop Engineering"] --> VE["Verification Engineering"]
+    VE <--> HE["Harness Engineering"]
+    VE --> PRE["PR Engineering"]
+```
+
+* **Upstream**: Loop Engineering (supplies completed code and checkpoints)
+* **Downstream**: Harness Engineering (invoked for full test/coverage execution), PR Engineering (receives quality gate verdict)
+
+---
+
+## Internal Phases
+
+### Phase 1: Full Suite Test & Regression Validation
+* **Objective**: Ensure no existing functionality was broken by changes.
+* **Actions**:
+  1. Invoke Harness Engineering (`TargetChecks: ["test", "coverage", "typecheck"]`).
+  2. Verify overall coverage meets `{{COVERAGE_THRESHOLD}}`% (100% for security/auth logic).
+* **Success Criteria**: 100% test pass rate; coverage meets or exceeds threshold.
+
+### Phase 2: Architecture & File Coupling Audit
+* **Objective**: Maintain clean codebase architecture and prevent monolith files.
+* **Actions**:
+  1. Check function line counts (`<= 50 lines`).
+  2. Check file line counts (`<= 800 lines`).
+  3. Check nesting levels (`<= 4 levels`).
+* **Success Criteria**: Zero architectural structural violations.
+
+### Phase 3: Coding Standards & Immutability Check
+* **Objective**: Enforce project coding style rules (`.agent/rules/coding-style.md`).
+* **Actions**:
+  1. Verify immutable data patterns (no direct object mutation).
+  2. Verify comprehensive error handling (no empty `catch` blocks or swallowed errors).
+  3. Check for leftover `console.log` or debug statements.
+* **Success Criteria**: 100% compliance with coding style checklist.
+
+### Phase 4: Security & Privacy Audit (CRITICAL)
+* **Objective**: Guarantee zero security vulnerabilities or privacy breaches.
+* **Actions**:
+  1. Scan diffs for hardcoded credentials, API keys, or Cognito secrets.
+  2. Verify path sanitization (no absolute local paths like `C:\Users\...`).
+  3. Check XSS, SQL/NoSQL injection, and CSRF prevention patterns.
+* **Success Criteria**: **ZERO** CRITICAL or HIGH security findings.
+
+### Phase 5: Acceptance Criteria Verification
+* **Objective**: Confirm implementation satisfies 100% of original goals.
+* **Actions**:
+  1. Map verified behaviors against `AcceptanceCriteria` defined during Planning.
+* **Success Criteria**: All acceptance criteria marked verified.
+
+### Phase 6: Quality Gate Decisioning
+* **Objective**: Issue definitive merge readiness decision.
+* **Decision Rules**:
+  - **APPROVE**: Zero CRITICAL/HIGH findings; tests pass; coverage meets threshold.
+  - **WARNING**: Only MEDIUM/LOW findings (e.g., minor stylistic issues).
+  - **BLOCK**: Any CRITICAL or HIGH finding, failing test, or type error.
+* **Success Criteria**: Formal verdict emitted in `QualityGateVerdict`.
+
+---
+
+## Execution Rules
+
+1. **Zero Tolerance for Security Flaws**: Any CRITICAL or HIGH security finding MUST automatically issue a `BLOCK` verdict.
+2. **Confidence-Based Filtering**: Only flag issues with > 80% confidence of being true defects to minimize noise.
+3. **Un-truncated Error Analysis**: Never pass a quality gate without inspecting full traceback evidence.
+4. **Independent Audit**: Verification Engineering MUST evaluate code independently without relying on agent self-claims.
+
+---
+
+## Guardrails
+
+* **Merge Blocker**: If verdict is `BLOCK`, PR creation MUST be halted.
+* **Absolute Path Sanitization**: Automatically fail verification if local machine paths are detected in modified files.
+
+---
+
+## Best Practices
+
+* Categorize findings clearly by severity: `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`, `[LOW]`.
+* Provide precise file location, line numbers, and actionable code fixes for every reported issue.
+
+---
+
+## Anti-Patterns
+
+* ❌ **Approving Vulnerabilities**: Passing code with exposed API keys because "it works".
+* ❌ **Pedantic Noise**: Flagging minor formatting preferences when code passes prettier checks.
+* ❌ **Ignoring Coverage Drop**: Approving PRs where code coverage dropped significantly below threshold.
+
+---
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+    A[Loop Execution Output] --> B[Phase 1: Full Regression & Coverage Check]
+    B -- Fail --> G[Issue BLOCK Verdict]
+    B -- Pass --> C[Phase 2: Architecture & Coupling Audit]
+    C --> D[Phase 3: Coding Standards & Immutability Check]
+    D --> E[Phase 4: Security & Privacy Audit]
+    E -- Security Flaw Found --> G
+    E -- Clean --> F[Phase 5: Acceptance Criteria Verification]
+    F --> H{Phase 6: Quality Gate Decision}
+    H -- All Checks Passed --> I[Emit APPROVE Verdict]
+    H -- Minor Medium/Low Issues --> J[Emit WARNING Verdict]
+    H -- Critical/High Issues --> G
+```
+
+---
+
+## Integration Points
+
+* **Loop Engineering**: Receives code changes from loop completion.
+* **Harness Engineering**: Invoked to run full test suites, coverage checks, and linters.
+* **PR Engineering**: Receives `QualityGateVerdict` to determine whether PR can be opened.
+
+---
+
+## Extensibility
+
+* **Automated Static Analysis Integration**: Phase 4 can be extended to query SonarQube, Snyk, or CodeQL APIs for enterprise security scanning.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,7 @@ export default withMermaid(defineConfig({
   title: 'My Roadmap',
   description: 'Learning Task Management Application - Professional portfolio project',
   base: '/MyRoadmap/',
+  ignoreDeadLinks: true,
   
   themeConfig: {
     nav: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,7 +25,8 @@ export default withMermaid(defineConfig({
           { text: 'Requirements Specification', link: '/requirements' },
           { text: 'Application Showcase', link: '/showcase' },
           { text: 'CI/CD Pipeline', link: '/cicd' },
-          { text: 'AI Development Guidelines', link: '/ai_development_guidelines' }
+          { text: 'AI Development Guidelines', link: '/ai_development_guidelines' },
+          { text: 'Task Breakdown (Issues)', link: '/issues_list' }
         ]
       },
       {
@@ -33,7 +34,16 @@ export default withMermaid(defineConfig({
         items: [
           { text: 'Financial Cost Estimation', link: '/financial_cost_estimation' },
           { text: 'Operations Policy', link: '/operations_policy' },
-          { text: 'Test Strategy', link: '/test_strategy' }
+          { text: 'Test Strategy', link: '/test_strategy' },
+          { text: 'Observability Roadmap', link: '/observability_roadmap' }
+        ]
+      },
+      {
+        text: 'Guides & Policies',
+        items: [
+          { text: 'Amplify Hosting Setup', link: '/setup-amplify-hosting' },
+          { text: 'Cognito Troubleshooting', link: '/troubleshooting-cognito' },
+          { text: 'Privacy Policy', link: '/privacy-policy' }
         ]
       }
     ],

--- a/docs/.vitepress/theme/components/LanguageToggle.vue
+++ b/docs/.vitepress/theme/components/LanguageToggle.vue
@@ -1,0 +1,68 @@
+<script setup>
+import { useLanguage } from '../composables/useLanguage'
+
+const { currentLang, setLang } = useLanguage()
+</script>
+
+<template>
+  <div class="header-lang-toggle">
+    <button
+      type="button"
+      :class="['lang-pill', { active: currentLang === 'ja' }]"
+      title="日本語に切り替え"
+      @click="setLang('ja')"
+    >
+      🇯🇵 JA
+    </button>
+    <button
+      type="button"
+      :class="['lang-pill', { active: currentLang === 'en' }]"
+      title="Switch to English"
+      @click="setLang('en')"
+    >
+      🇬🇧 EN
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.header-lang-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--vp-c-bg-soft, #f6f6f7);
+  border: 1px solid var(--vp-c-divider, rgba(82, 82, 89, 0.2));
+  border-radius: 9999px;
+  padding: 2px;
+  margin-left: 12px;
+  margin-right: 8px;
+  vertical-align: middle;
+  height: 28px;
+}
+
+.lang-pill {
+  border: none;
+  background: transparent;
+  color: var(--vp-c-text-2, #888);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  cursor: pointer;
+  line-height: 1.2;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.lang-pill:hover {
+  color: var(--vp-c-text-1, #111);
+}
+
+.lang-pill.active {
+  background: var(--vp-c-brand-1, #3eaf7c);
+  color: #ffffff;
+  box-shadow: 0 1px 4px rgba(62, 175, 124, 0.3);
+}
+</style>

--- a/docs/.vitepress/theme/composables/useLanguage.ts
+++ b/docs/.vitepress/theme/composables/useLanguage.ts
@@ -1,0 +1,30 @@
+import { ref } from 'vue'
+
+const currentLang = ref<'ja' | 'en'>('ja')
+
+// Read initial setting from localStorage if running in browser
+if (typeof window !== 'undefined') {
+  const saved = localStorage.getItem('myroadmap_docs_lang')
+  if (saved === 'ja' || saved === 'en') {
+    currentLang.value = saved
+  }
+}
+
+export function useLanguage() {
+  const setLang = (lang: 'ja' | 'en') => {
+    currentLang.value = lang
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('myroadmap_docs_lang', lang)
+    }
+  }
+
+  const toggleLang = () => {
+    setLang(currentLang.value === 'ja' ? 'en' : 'ja')
+  }
+
+  return {
+    currentLang,
+    setLang,
+    toggleLang
+  }
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -9,3 +9,19 @@
 .medium-zoom-image--opened {
   z-index: 101 !important;
 }
+
+/* Global Language Toggle Content Transition */
+.lang-content {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -1,12 +1,18 @@
 import DefaultTheme from 'vitepress/theme'
 import mediumZoom from 'medium-zoom'
-import { onMounted, watch, nextTick } from 'vue'
+import { onMounted, watch, nextTick, h } from 'vue'
 import { useRoute } from 'vitepress'
 
+import LanguageToggle from './components/LanguageToggle.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'nav-bar-content-after': () => h(LanguageToggle)
+    })
+  },
   setup() {
     const route = useRoute()
     const initZoom = () => {

--- a/docs/ai_development_guidelines.md
+++ b/docs/ai_development_guidelines.md
@@ -8,10 +8,10 @@ This document outlines the rules of engagement and best practices for developing
 
 AI assistants are powerful but prone to over-engineering or hallucinating complex solutions when given overly broad prompts. We mitigate this through **strict control and verification**.
 
-### 1.1 Small Chunking (Granular Issues)
+### 1.1 Small Chunking (Granular Micro-Tasks)
 - **Rule**: Never ask the AI to build an entire feature (e.g., "Build the dashboard") in a single prompt.
-- **Action**: Break down features into explicit, atomic GitHub Issues (S size, 1-2 hours).
-- **Execution**: Instruct the AI to focus *only* on the current Issue. One Pull Request (PR) must equal one specific objective.
+- **Action**: Break down features into explicit, atomic micro-tasks (Size **XS** `< 1h` or **S** `1-2h`).
+- **Execution**: Instruct the AI to focus *only* on the current micro-task. One Pull Request (PR) must equal one specific objective.
 
 ### 1.2 Test-Driven AI (TDAI)
 - **Rule**: Define the expected behavior before writing the implementation.
@@ -58,6 +58,45 @@ The quality of AI output is directly proportional to the context provided.
 AI code can become disjointed over multiple sessions.
 - **Rule**: Refactor early and often.
 - **Action**: After completing a major feature, dedicate a session solely to cleaning up the code, extracting reusable components (shadcn/ui), and consolidating duplicated logic. Do not add new features during a refactoring session.
+
+---
+
+## 5. Autonomous AI Engineering System & Loop Architecture
+
+To support systematic, agent-first execution, the repository implements a modular **AI Engineering Operating System** comprising 7 composable workflow modules located under `.agent/workflows/`.
+
+```mermaid
+graph TD
+    PE["1. Prompt Engineering"] --> CE["2. Context Engineering"]
+    CE --> PL["3. Planning Engineering"]
+    PL --> LE["4. Loop Engineering"]
+    LE <--> HE["Harness Engineering (Vitest / TSC)"]
+    LE --> VE["5. Verification Engineering"]
+    VE --> PRE["6. PR Engineering"]
+```
+
+### 5.1 The Autonomous Loop Execution Framework (`/loop-engineering`)
+
+The core execution engine operates autonomously in iterative, step-by-step micro-task cycles:
+
+1. **Phase 1: Task Queue & Scope Pre-Check**:
+   - Decomposes goals into XS/S micro-tasks via **Planning Engineering**.
+   - Checks destructive operations: Actions requiring major directory deletion or DB resets trigger a mandatory **Approval Hook**.
+2. **Phase 2: Iterative TDD Loop (RED → GREEN → REFACTOR)**:
+   - **RED**: Writes failing unit/component tests in Vitest.
+   - **GREEN**: Implements minimal production code to pass the test.
+   - **REFACTOR**: Cleans code and verifies zero regression via **Harness Engineering**.
+3. **Phase 3: Dual Circuit Breaker & Safety Policies**:
+   - **Task-Level Limit**: Maximum **3 consecutive retries** for the same error on a single micro-task.
+   - **Cumulative Loop Limit**: Maximum **5 cumulative retries** across an entire loop session.
+   - **Circuit Breaker Action**: Exceeding retry limits halts execution immediately, reverts to the last git checkpoint (`git checkout -- .`), and alerts the human developer.
+4. **Phase 4: Token & Cost Guardrails**:
+   - **Micro-Task Scope Limit**: Maximum **3 files modified** and **< 200 lines changed** per task.
+   - **Run Execution Limit**: Maximum **5 micro-tasks** per single loop invocation.
+   - **Targeted Context Refresh**: Context Engineering re-reads only modified files to conserve token budget.
+5. **Phase 5: Quality Gate & Handover**:
+   - **Verification Engineering** audits code for zero security defects, path sanitization (relative paths only), and 80%+ test coverage.
+   - **PR Engineering** formats Conventional Commit summaries, collates test evidence, and opens a Pull Request (`gh pr create`).
 
 ---
 

--- a/docs/ai_development_guidelines.md
+++ b/docs/ai_development_guidelines.md
@@ -1,3 +1,122 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# AIネイティブ開発ガイドライン (AI-Native Development Guidelines)
+
+本ドキュメントは、AIコーディングアシスタントを活用して **My Roadmap** プロジェクトを開発する際のルールおよびベストプラクティスを定義します。目的は、生産性を最大化しつつ、技術負債、アーキテクチャのドリフト（逸脱）、およびブラックボックスコードの蓄積を厳格に防止することです。
+
+---
+
+## 1. コア原則: 「AI暴走・肥大化」の防止
+
+AIアシスタントは非常に強力ですが、あいまいまたは範囲の広すぎるプロンプトが与えられると、オーバーエンジニアリングや存在しないソリューションのハルシネーション（幻想）を引き起こす傾向があります。私たちは **厳格なコントロールと自動検証** によりこれを防ぎます。
+
+### 1.1 マイクロタスク化 (Granular Micro-Tasks)
+- **ルール**: 「ダッシュボードを作成して」といった機能全体の構築を 1 つのプロンプトで要求しないこと。
+- **アクション**: 機能を明確かつアトミックなマイクロタスク (サイズ **XS** `< 1h` または **S** `1-2h`) に分解する。
+- **実行**: AIに対し、現在のマイクロタスク *のみ* に集中するよう指示する。1つの Pull Request (PR) は 1つの明確な目的に対応させる。
+
+### 1.2 テスト駆動AI開発 (Test-Driven AI / TDAI)
+- **ルール**: 実装コードを書く前に期待される動作を定義する。
+- **アクション**: 複雑なロジックについては、AIに単体テスト (Vitest) またはバリデーションスキーマ (Zod) を *最初に* 書かせる。
+- **実行**: テストコードを人間がレビューし承認する。その後にのみ、テストを通過させるための最小限の実装コードを書かせる。
+
+### 1.3 批判的レビューと「説明義務」ルール
+- **ルール**: 自分が完全に理解していないコードを盲目的に受け入れないこと。
+- **アクション**: AIが複雑なアーキテクチャ、見慣れないライブラリ、密なコードブロックを提案した場合は実行を中断する。
+- **実行**: 説明を要求する ("このコードを1行ずつ説明してください")。またはリファクタリングを指示する ("KISS原則に従い、よりシンプルで保守しやすいアプローチで書き直してください")。
+
+---
+
+## 2. 品質ゲートとしてのインフラストラクチャ (CI/CD)
+
+人間のレビューで見落とされる可能性のあるAIのエラーを捕らえるため、自動化システムに依存します。
+
+### 2.1 厳格なリンティングと型定義
+- AIは ESLint 設定および TypeScript の `strict: true` モードに厳格に従わなければならない。
+- `any` や `@ts-ignore` の使用は、文書化された正当な理由で明示的に認可されない限り厳禁。
+
+### 2.2 CI/CD による強制
+- AIが生成したすべての PR は、GitHub Actions CI パイプライン (Typecheck, Lint, Tests) を通過しなければならない。
+- CI が失敗した場合、エラーログを AI にフィードバックしてステップバイステップでデバッグさせる。AIは不快な症状の隠蔽ではなく根本原因を修正しなければならない。
+
+---
+
+## 3. コンテキスト管理とプロンプトエンジニアリング
+
+AIの出力品質は、提供されるコンテキストの精度に直結します。
+
+### 3.1 「コンテキストルール」
+- **ルール**: AIは新しいタスクを開始する前に、必ず `docs/requirements.md`、`project-context.md`、および本 `ai_development_guidelines.md` を参照しなければならない。
+- **アクション**: AIが技術スタック (Next.js App Router, Tailwind, Amplify Gen 2 等) を正確に認識し、古いパターンのコードを出力しないよう徹底する。
+
+### 3.2 実装計画 (Implementation Plans)
+- **ルール**: 計画なしにコードを書いてはならない。
+- **アクション**: AIは現在のタスクに対する詳細なステップバイステップの `implementation_plan.md` を出力し、ファイル修正を実行する前に **人間の明示的な承認を待たなければならない**。
+
+---
+
+## 4. 継続的リファクタリング (Continuous Refactoring)
+
+AIが作成したコードは、複数のセッションにまたがると断片化する可能性があります。
+- **ルール**: 早期かつ高頻度でリファクタリングを行う。
+- **アクション**: 主要機能を完了した後は、コードのクリーンアップ、再利用可能コンポーネント (shadcn/ui) の抽出、重複ロジックの統合専用セッションを設ける。リファクタリングセッション中に新機能を追加してはならない。
+
+---
+
+## 5. 自律型AIエンジニアリングシステム & ループアーキテクチャ
+
+系統的でエージェントファーストな実行をサポートするため、本リポジトリには `.agent/workflows/` 下に 7 つのコンポーザブルな **AI Engineering OS** ワークフローモジュールが組み込まれています。
+
+```mermaid
+graph TD
+    PE["1. Prompt Engineering"] --> CE["2. Context Engineering"]
+    CE --> PL["3. Planning Engineering"]
+    PL --> LE["4. Loop Engineering"]
+    LE <--> HE["Harness Engineering (Vitest / TSC)"]
+    LE --> VE["5. Verification Engineering"]
+    VE --> PRE["6. PR Engineering"]
+```
+
+### 5.1 自律型ループ実行フレームワーク (`/loop-engineering`)
+
+中核となる実行エンジンは、ステップバイステップのマイクロタスクサイクルで自律的に動作します：
+
+1. **Phase 1: タスクキュー & スコープ事前チェック**:
+   - **Planning Engineering** 経由で目標を XS/S サイズのマイクロタスクに分解。
+   - 破壊的操作の確認: 大規模なディレクトリ削除や DB リセットを必要とするアクションは、義務的な **Approval Hook** を起動。
+2. **Phase 2: イテレーティブ TDD ループ (RED → GREEN → REFACTOR)**:
+   - **RED**: Vitest で失敗するテストを書く。
+   - **GREEN**: テストをパスする最小限のプロダクションコードを実装。
+   - **REFACTOR**: コードを整理し、**Harness Engineering** 経由でデグレがないことを確認。
+3. **Phase 3: 二重サーキットブレーカー & 安全ポリシー**:
+   - **タスクレベル上限**: 同一エラーでのリトライは最大 **3回**。
+   - **累積ループ上限**: 1セッション全体の累積リトライは最大 **5回**。
+   - **動作**: 限界値を超えた場合は直ちに実行を停止 (HALT) し、直前のチェックポイントにロールバック (`git checkout -- .`) して人間へアラートを送信。
+4. **Phase 4: トークン & コスト保護ガードレール**:
+   - **マイクロタスクスコープ上限**: 1タスクあたり最大 **3ファイル変更** および **< 200行差分**。
+   - **連続実行上限**: 1回のループ呼び出しあたり最大 **5マイクロタスク**。
+   - **ターゲット限定 Context Refresh**: トークン予算を節約するため、変更されたファイルのみをメモリ再読み込み。
+5. **Phase 5: 品質ゲート & 引き渡し**:
+   - **Verification Engineering** がセキュリティ上の欠陥ゼロ、相対パスの徹底、カバレッジ 80%+ を監査。
+   - **PR Engineering** が Conventional Commit サマリーを整え、テスト証拠をまとめた上で Pull Request を作成 (`gh pr create`)。
+
+---
+
+## 付録: コミュニケーションプロトコル (ハイブリッド仕様)
+
+- 要件検討、ロジック議論、詳細プロンプト設計: **日本語**
+- ソースコード変数、関数名、インラインコメント、コミットメッセージ (Conventional Commits), PR本文: **英語**
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # AI-Native Development Guidelines
 
 This document outlines the rules of engagement and best practices for developing the **My Roadmap** project using AI coding assistants. The goal is to maximize productivity while strictly preventing the accumulation of technical debt, architectural drift, and "black box" code.
@@ -104,3 +223,5 @@ The core execution engine operates autonomously in iterative, step-by-step micro
 
 - Deep dives, logic discussions, and complex planning: **Japanese**
 - Source code variables, function names, inline comments, commit messages (Conventional Commits), PR descriptions: **English**
+
+</div>

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,3 +1,84 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# CI/CD パイプライン仕様書 (CI/CD Pipeline Specification)
+
+本ドキュメントは、「My Roadmap」プロジェクトにおける継続的インテグレーション (CI) および継続的デプロイメント (CD) のワークフロー仕様を記載したものです。
+
+## 1. 概要 (Overview)
+
+本プロジェクトでは、GitHub Actions を使用して自動テストおよび AWS Amplify へのデプロイを行っています。
+
+- **CI**: すべての Pull Request に対してリンティング、型チェック、およびビルド検証を自動実行。
+- **CD**: セミオートマチック（半自動）デプロイ戦略。コスト最適化とセキュリティ確保のため、マージ時の自動デプロイは無効化されており、スケジュールまたは管理者承認付きの昇認トリガーでデプロイを実行します。
+
+---
+
+## 2. 継続的インテグレーション (CI)
+
+### ワークフロー: `Next.js CI` (`.github/workflows/ci.yml`)
+
+- **トリガー**: `main` ブランチへのプッシュおよび `main` をターゲットとするすべての Pull Request。
+- **実行環境**: Node.js 20.x, Ubuntu latest。
+
+#### 主な実行ステップ:
+1. **依存関係のインストール**: `npm install` を使用。WindowsとCI環境間の差異を防ぐため、パイプライン内ではインストール前に `package-lock.json` を再生成します。
+2. **型チェック**: `npm run typecheck` を実行し、TypeScript の型安全性を確認。
+3. **リンティング**: `npm run lint` (ESLint) を実行してコード品質を維持。
+4. **ビルド検証**: `npm run build` を実行し、Next.js アプリケーションが正常にコンパイルされることを検証。
+
+---
+
+## 3. 継続的デプロイメント (CD)
+
+AWS Amplify への **セミオートマチック（半自動）** デプロイ戦略を採用しています。
+
+### ワークフロー: `Amplify Deploy` (`.github/workflows/deploy.yml`)
+
+#### A. スケジュールデプロイ
+- **スケジュール**: 毎月 1 日 23:00 JST (`0 14 1 * *` UTC)。
+- **目的**: 手動操作なしで定期的な「マンスリーリリース」を提供。
+
+#### B. 手動デプロイ
+- **トリガー**: `workflow_dispatch` (GitHub UI からの手動トリガー)。
+- **要件**: 「管理者承認 (Admin Approval)」が設定された環境での実行。
+- **ログ記録**: デプロイ実行の理由は GitHub Actions のサマリーに自動記録。
+
+### デプロイ処理ロジック (`amplify.yml`)
+1. **バックエンド**: `npx ampx pipeline-deploy` により AWS リソース (Auth, Data) をデプロイ。
+2. **フロントエンド**: Next.js アプリケーションをビルド。
+3. **キャッシュ**: 後続ビルドの高速化のため、Node モジュールおよび Next.js ビルドキャッシュを保持。
+
+---
+
+## 4. 将来ロードマップ
+
+### 4.1 自動通知の導入 (計画中)
+リアルタイムのステータス通知のため **Slack** との連携を予定。
+- **詳細**: [Issue #63](https://github.com/Vanilla2412/MyRoadmap/issues/63) を参照。
+- **イベント**: CI/CD の成功および失敗の通知。
+
+### 4.2 ステージング環境の拡充
+現在は単一の `main` ブランチで運用していますが、将来のイテレーションで以下を検討：
+- Pull Request ごとのプレビューデプロイ。
+- ステージング専用の `develop` ブランチの構築。
+
+---
+
+## 5. セキュリティ & クレデンシャル管理
+
+- すべての AWS クレデンシャルおよび App ID は **GitHub Secrets** に安全に保存。
+- 本番環境へのデプロイには、リポジトリ管理者からの手動承認が必要。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # CI/CD Pipeline Specification
 
 This document details the Continuous Integration (CI) and Continuous Deployment (CD) workflows for the **My Roadmap** project.
@@ -55,8 +136,6 @@ Integration with **Slack** is planned to provide real-time status updates.
 - **Details**: See [Issue #63](https://github.com/Vanilla2412/MyRoadmap/issues/63).
 - **Events**: Notifications for CI/CD success and failure.
 
-### 4.2 Testing Expansion
-
 ### 4.2 Staging Environments
 Currently, the project operates on a single `main` branch. Future iterations may include:
 - Preview deployments for Pull Requests.
@@ -68,3 +147,6 @@ Currently, the project operates on a single `main` branch. Future iterations may
 
 - All AWS credentials and App IDs are stored securely in **GitHub Secrets**.
 - Deployments to the production environment require manual approval from a repository administrator.
+
+</div>
+

--- a/docs/financial_cost_estimation.md
+++ b/docs/financial_cost_estimation.md
@@ -1,3 +1,52 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# 財務コスト試算および試算分析 (Financial Cost Estimation)
+
+本ドキュメントは、「My Roadmap」アプリケーションにおける AWS 運用コストの内訳試算を提供します。MVPフェーズおよび AWS 無料利用枠（Free Tier）を超過した後の移行ポイントに焦点を当てています。
+
+## 1. AWS サービス別コスト内訳 (MVP規模)
+
+適度なタスク管理アクティビティを行う月間アクティブユーザー数約 100人 (100 MAU) を想定。
+
+| サービス名 | コンポーネント | 無料利用枠 (Free Tier) | 推定月額コスト (無料枠超過後) |
+| :--- | :--- | :--- | :--- |
+| **AWS Amplify** | ホスティング & ビルド | 月 1,000 ビルド分, 5GB ストレージ, 15GB 転送量 | ビルド $0.01/分, ストレージ $0.023/GB, 転送量 $0.15/GB |
+| **AWS Cognito** | 認証機能 | 月 50,000 MAU | 50,000 MAU 超過分 $0.0055/MAU |
+| **Amazon DynamoDB** | データストレージ | 25GB ストレージ, 25 WCU/RCU | ストレージ ~$0.25/GB, 100万書き込み ~$1.25 (オンデマンド) |
+| **AWS AppSync** | GraphQL API | 月 250,000 クエリ (最初の12か月) | 100万クエリあたり $4.00 |
+| **CloudWatch** | ログ & メトリクス | 5GB ログ, 3 ダッシュボード, 10 アラーム | 5GB 超過分 $0.50/GB |
+
+## 2. 推定月額合計コスト
+
+- **AWS 無料利用枠内**: **$0.00**
+- **無料枠わずかに超過時 (小規模運用)**: **$5.00 未満**
+- **成長フェーズ (1,000+ ユーザー)**: **$10.00 - $30.00** (主に Amplify データ転送量および AppSync クエリ数による)
+
+## 3. コストのしきい値と最適化戦略
+
+### コスト影響の大きいしきい値
+- **Amplify データ転送量**: 大容量画像アセットや高トラフィックにより 15GB 無料枠を早期消費するリスク。
+- **AppSync クエリボリューム**: 高頻度のポーリングを行う複雑なフロントエンドは最適化が必要。
+
+### 最適化戦略
+- **ログ保持期間**: CloudWatch ログの保持期間を 14日 に制限しストレージ費用を抑制。
+- **DynamoDB キャパシティ**: 予想しにくいトラフィックにはオンデマンドキャパシティを使用。
+- **Amplify ビルド**: ビルドスクリプトを最適化し、デプロイごとのビルド時間を 5分以内 に保持。
+
+## 4. ステークホルダー向け要約
+
+本プロジェクトは極めて費用対効果が高く設計されており、開発および初期運用フェーズ全体を通じて **AWS 無料利用枠** 内に収まります。AWS Budgets による継続的モニタリングにより、予期せぬスケールや設定ミスを早期発見します。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Financial Cost Estimation and Analysis
 
 This document provides a breakdown of the estimated operating costs for "My Roadmap" on AWS, focusing on the MVP phase and transition points beyond the AWS Free Tier.
@@ -34,3 +83,6 @@ Estimated for ~100 monthly active users (MAU) with moderate task management acti
 ## 4. Summary for Stakeholders
 
 The project is designed to be highly cost-effective, remaining within the **AWS Free Tier** for the entire development and initial launch phase. Ongoing monitoring via AWS Budgets will ensure that any unexpected scaling or misconfiguration is caught before significant charges are incurred.
+
+</div>
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,41 @@ features:
     details: GraphQL API with AWS AppSync for efficient data synchronization
 ---
 
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+## プロジェクト概要
+
+**My Roadmap** は、ユーザーが自身の学習目標を体系的に管理・追跡するための学習タスク管理アプリケーションです。本プロジェクトは、モダンなWeb開発のベストプラクティスとエンタープライズグレードのクラウドアーキテクチャを実証するポートフォリオとして設計されています。
+
+### 技術スタック (Tech Stack)
+
+- **フロントエンド (Frontend)**: Next.js (App Router), TypeScript, Tailwind CSS, shadcn/ui
+- **バックエンド (Backend)**: AWS Amplify Gen 2 (Infrastructure as Code via TypeScript)
+- **認証 (Authentication)**: AWS Cognito
+- **データベース (Database)**: Amazon DynamoDB
+- **API**: AWS AppSync (GraphQL)
+- **CI/CD**: GitHub Actions
+
+### 主要ドキュメント (Documentation)
+
+- [要件定義書 (/requirements)](/requirements) - 機能要件および非機能要件の詳細仕様
+- [アプリ画面ショーケース (/showcase)](/showcase) - 各画面のUIデザイン・主要機能ハイライト
+- [CI/CD パイプライン (/cicd)](/cicd) - 自動テスト・ビルド・デプロイフロー仕様
+- [AI開発ガイドライン (/ai_development_guidelines)](/ai_development_guidelines) - AIエージェントを活用した開発基準
+- [運用ポリシー (/operations_policy)](/operations_policy) - コスト管理・リソースハイジーン・DR手順
+- [テスト戦略 (/test_strategy)](/test_strategy) - VitestおよびTDD自律ループ仕様
+- [可観測性ロードマップ (/observability_roadmap)](/observability_roadmap) - ログ・RUM・X-Ray・SLO戦略
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 ## Project Overview
 
 **My Roadmap** is a learning task management application designed to help users systematically track and organize their learning goals. This project demonstrates modern web development practices and enterprise-grade architecture.
@@ -50,4 +85,12 @@ features:
 ### Documentation
 
 - [Requirements Specification](/requirements) - Comprehensive functional and non-functional requirements
+- [Application Showcase](/showcase) - UI screen designs and feature highlights
 - [CI/CD Pipeline](/cicd) - Automated testing and deployment specifications
+- [AI Development Guidelines](/ai_development_guidelines) - Guidelines for AI-driven development
+- [Operations Policy](/operations_policy) - Cost management, resource hygiene, and DR policy
+- [Test Strategy](/test_strategy) - Vitest and autonomous TDD loop strategy
+- [Observability Roadmap](/observability_roadmap) - Structured logging, RUM, X-Ray, and SLO strategy
+
+</div>
+

--- a/docs/issues_list.md
+++ b/docs/issues_list.md
@@ -1,164 +1,137 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# MVP 開発タスク分解一覧 (Issues Breakdown)
+
+本ドキュメントは、「My Roadmap」の MVP 開発における各ステップを 1〜2 時間（サイズ: S）の扱いやすいタスクに分解した GitHub Issues の定義一覧です。
+
+## Step 2: 認証機能 (Authentication)
+
+### Issue 1: Amplify Gen2 認証リソースの定義
+- **タイトル**: `feat: define Amplify Gen 2 Auth resource`
+- **概要**: Cognito を使用した Eメールサインアップのバックエンド認証ルールを構成。
+- **受入基準**:
+  - [ ] `web/amplify/auth/resource.ts` が Eメールログインロジックで更新されていること。
+  - [ ] `npx ampx sandbox` がエラーなくプロビジョニング完了すること。
+
+### Issue 2: ログインおよびサインアップ UI の実装
+- **タイトル**: `feat: implement login and signup UI`
+- **概要**: Amplify Authenticator を統合したログイン・アカウント作成画面の実装。
+- **受入基準**:
+  - [ ] ログイン用ルート (`/login` 等) を作成。
+  - [ ] Amplify Authenticator コンポーネントを組み込み。
+
+### Issue 3: 保護されたルート向け Next.js ミドルウェア
+- **タイトル**: `feat: implement protected routes via Next.js Middleware`
+- **概要**: 認証済みユーザーのみがタスクダッシュボードにアクセスできるように制御。
+- **受入基準**:
+  - [ ] `middleware.ts` を作成し、Amplify Auth セッション状態をチェック。
+  - [ ] 未認証ユーザーをログインページへリダイレクト。
+
+---
+
+## Step 3: バックエンドデータモデル
+
+### Issue 4: Task データモデルの定義 (DynamoDB & AppSync)
+- **タイトル**: `feat: define Task data model with owner authorization`
+- **概要**: `web/amplify/data/resource.ts` 内で所有者ベースのアクセス権限を持つ `Task` モデルを定義。
+
+---
+
+## Step 4: フロントエンド UI の実装
+
+### Issue 5: タスクダッシュボード UI
+- **タイトル**: `feat: implement Task Dashboard layout and list rendering`
+- **概要**: AppSync API からタスクを取得し、shadcn/ui コンポーネントで描画。
+
+### Issue 6: タスク作成フォーム (React Hook Form + Zod)
+- **タイトル**: `feat: implement Task creation form`
+- **概要**: Zod バリデーション付きのタスク作成モーダルフォーム。
+
+### Issue 7: タスク編集・削除機能
+- **タイトル**: `feat: implement Edit and Delete actions for Tasks`
+- **概要**: 既存タスクの更新および DynamoDB からの削除機能。
+
+---
+
+## Step 5 〜 Step 8: 運用・信頼性・将来計画
+
+- **Issue 8**: Amplify Hosting デプロイ設定
+- **Issue 9**: CI/CD パイプラインにおける Slack 通知機能
+- **Issue 10**: コミュニティ標準ドキュメント (`CONTRIBUTING.md`, `SECURITY.md`) の作成
+- **Issue 11**: 財務コスト試算および試算分析 ([financial_cost_estimation.md](/financial_cost_estimation))
+- **Issue 12**: Phase 3 AWS コスト設計および運用ポリシー ([operations_policy.md](/operations_policy))
+- **Issue 13**: Phase 4 AI 機能統合および MLOps 基盤の研究
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # MVP Development Task Breakdown (Issues)
 
-These are the 1-2 hour estimation tasks (Size: S) broken down from `memo.md` for Step 2 and beyond. You can copy the content below to create new GitHub Issues using the template we just created.
+These are the 1-2 hour estimation tasks (Size: S) broken down from development roadmaps. You can use these titles and criteria to create GitHub Issues.
 
 ## Step 2: Authentication
 
 ### Issue 1: Amplify Gen2 Auth resource definition
-
 - **Title**: `feat: define Amplify Gen 2 Auth resource`
-- **Context**: We need to configure the backend authentication rules using email sign-up for Cognito.
+- **Context**: Configure backend authentication rules using email sign-up for Cognito.
 - **Acceptance Criteria**:
   - [ ] `web/amplify/auth/resource.ts` is updated with email sign-in logic.
-  - [ ] Running `npx ampx sandbox` launches successfully and provisions the Auth resource without errors.
-- **Estimated Size**: `S (1-2h)`
+  - [ ] Running `npx ampx sandbox` launches successfully without errors.
 
 ### Issue 2: Login and Signup UI Implementation
-
 - **Title**: `feat: implement login and signup UI`
-- **Context**: The frontend needs a way to present login options to the user, integrating the Amplify Authenticator.
+- **Context**: Present login and signup options using Amplify Authenticator.
 - **Acceptance Criteria**:
-  - [ ] Create a dedicated login route (`/login` or similar).
-  - [ ] Embed the Amplify Authenticator component.
-  - [ ] UI is rendered correctly and accepts user input.
-- **Estimated Size**: `S (1-2h)`
+  - [ ] Create dedicated login route (`/login`).
+  - [ ] Embed Amplify Authenticator component.
 
 ### Issue 3: Next.js Middleware for Protected Routes
-
 - **Title**: `feat: implement protected routes via Next.js Middleware`
-- **Context**: Only authenticated users should be able to access the Task Dashboard.
+- **Context**: Only authenticated users should access the Task Dashboard.
 - **Acceptance Criteria**:
-  - [ ] Create or update `middleware.ts` to check Amplify Auth session state.
-  - [ ] Unauthenticated users are redirected to the login page.
-  - [ ] Authenticated users can successfully access the protected dashboard route.
-- **Estimated Size**: `S (1-2h)`
+  - [ ] Create or update `middleware.ts` to check Amplify Auth session.
+  - [ ] Unauthenticated users are redirected to login page.
 
 ---
 
 ## Step 3: Backend Data Model
 
 ### Issue 4: Task Data Model definition (DynamoDB & AppSync)
-
 - **Title**: `feat: define Task data model with owner authorization`
-- **Context**: Users need a DynamoDB table to store their tasks. We need to define the schema and ensure owner-based access control.
-- **Acceptance Criteria**:
-  - [ ] `web/amplify/data/resource.ts` defines the `Task` model (title, status, priority, dueDate, category).
-  - [ ] Authorization rules (`allow.owner()`) are applied to the model.
-  - [ ] `amplify sandbox` applies the DB schema correctly.
-- **Estimated Size**: `S (1-2h)`
+- **Context**: Define the `Task` schema in `web/amplify/data/resource.ts` with `allow.owner()` rules.
 
 ---
 
 ## Step 4: Frontend UI Implementation
 
 ### Issue 5: Task Dashboard UI
-
 - **Title**: `feat: implement Task Dashboard layout and list rendering`
-- **Context**: Displaying the user's tasks using shadcn/ui components.
-- **Acceptance Criteria**:
-  - [ ] Fetch tasks from the AppSync API.
-  - [ ] Render the tasks in a list/table format using shadcn/ui.
-  - [ ] Loading states are handled gracefully.
-- **Estimated Size**: `S (1-2h)`
+- **Context**: Display user tasks using AppSync API and shadcn/ui components.
 
 ### Issue 6: Task Creation Form (React Hook Form + Zod)
-
 - **Title**: `feat: implement Task creation form`
-- **Context**: Users need a validated form to create new tasks.
-- **Acceptance Criteria**:
-  - [ ] Create a form mapped to a Zod schema matching the Task data model.
-  - [ ] Integrate React Hook Form for state management.
-  - [ ] Upon submission, a new task is created via the GraphQL API and the dashboard updates.
-- **Estimated Size**: `S (1-2h)`
+- **Context**: Validated form to create new tasks mapped to Zod schema.
 
 ### Issue 7: Task Edit and Delete Functionality
-
 - **Title**: `feat: implement Edit and Delete actions for Tasks`
-- **Context**: Users must be able to update task status or delete tasks entirely.
-- **Acceptance Criteria**:
-  - [ ] Add an "Edit" and "Delete" button per task.
-  - [ ] Edit functionality updates existing records in DynamoDB.
-  - [ ] Delete functionality removes the task and refreshes the UI.
-- **Estimated Size**: `S (1-2h)`
+- **Context**: Update status or delete tasks directly in DynamoDB.
 
 ---
 
-## Step 5: Deployment
+## Step 5 - Step 8: Operations & Roadmap
 
-### Issue 8: AWS Amplify Hosting Deployment Configuration
+- **Issue 8**: AWS Amplify Hosting Deployment Configuration
+- **Issue 9**: Implement Slack Notifications for CI/CD Pipeline
+- **Issue 10**: GitHub Release Notes and Community Standards
+- **Issue 11**: Financial Cost Estimation and Analysis ([financial_cost_estimation.md](/financial_cost_estimation))
+- **Issue 12**: Phase 3 AWS Cost Design and Operations Policy ([operations_policy.md](/operations_policy))
+- **Issue 13**: Phase 4 AI Integration and MLOps Foundation
 
-- **Title**: `chore: configure Amplify Hosting deployment logic`
-- **Context**: The MVP must be accessible to the public on AWS via Amplify Hosting.
-- **Acceptance Criteria**:
-  - [ ] The app is successfully built in the Amplify CI/CD console or via AWS CDK setup.
-  - [ ] The live URL is active and functional.
-- **Estimated Size**: `S (1-2h)`
-
----
-
-## Step 6: Observability & Notifications
-
-### Issue 9: Implement Slack Notifications for CI/CD Pipeline
-
-- **Title**: `feat: implement Slack notifications for CI/CD status`
-- **GitHub Issue**: [Closes #63](https://github.com/Vanilla2412/MyRoadmap/issues/63)
-- **Context**: Real-time feedback on build and deployment status is crucial for development efficiency.
-- **Acceptance Criteria**:
-  - [x] Create a Slack Inbox Webhook.
-  - [x] Store the Webhook URL in GitHub Secrets as `SLACK_WEBHOOK_URL`.
-  - [x] Update `ci.yml` and `deploy.yml` to include notification steps.
-  - [x] Verify that notifications are received in Slack for both success and failure states.
-- **Estimated Size**: `S (1-2h)`
-
----
-
-## Step 7: Project Standards & Sustainability
-
-### Issue 10: GitHub Release Notes and Community Standards
-
-- **Title**: `chore: implement GitHub Release Notes and Community Standards`
-- **GitHub Issue**: [issue #64](https://github.com/Vanilla2412/MyRoadmap/issues/64)
-- **Context**: Transitioning the repository from a personal script to an open-source grade project requires standardized community files and automated versioning.
-- **Acceptance Criteria**:
-  - [ ] Create `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md`.
-  - [ ] Configure GitHub Actions to automate release note generation (e.g., via `release-drafter`).
-  - [ ] Document the project's versioning strategy (SemVer).
-- **Estimated Size**: `S (1-2h)`
-
-### Issue 11: Financial Cost Estimation and Analysis
-
-- **Title**: `docs: conduct project financial cost estimation and analysis`
-- **GitHub Issue**: [issue #65](https://github.com/Vanilla2412/MyRoadmap/issues/65)
-- **Context**: Demonstrating cost-awareness is a key engineering skill. We need to estimate the operating costs on AWS.
-- **Acceptance Criteria**:
-  - [ ] Research and estimate monthly costs for Amplify, Cognito, DynamoDB, and AppSync.
-  - [ ] Identify cost transition points when scaling beyond the AWS Free Tier.
-  - [ ] Create a cost analysis report in Markdown.
-- **Estimated Size**: `S (1-2h)`
-
----
-
-## Step 8: Future Planning (Phase 3 & 4)
-
-### Issue 12: Phase 3 - AWS Cost Design and Operations Policy
-
-- **Title**: `feat: define Phase 3 AWS cost design and operations policy`
-- **GitHub Issue**: [issue #66](https://github.com/Vanilla2412/MyRoadmap/issues/66)
-- **Context**: Operational excellence involves designing for cost-efficiency and reliable maintenance.
-- **Acceptance Criteria**:
-  - [x] Define budget alerts and cost monitoring strategies. (Implemented in PR #71)
-  - [x] Design resource management policies (log retention, cleanup schedules).
-  - [x] Establish a disaster recovery and automated backup policy.
-- **Estimated Size**: `S (1-2h)`
-
-### Issue 13: Phase 4 - AI Integration and MLOps Foundation
-
-- **Title**: `feat: research Phase 4 AI integration and MLOps foundation`
-- **GitHub Issue**: [issue #67](https://github.com/Vanilla2412/MyRoadmap/issues/67)
-- **Context**: Preparing for AI features and building the foundation for MLOps skills.
-- **Acceptance Criteria**:
-  - [ ] Define requirements for AI features (e.g., auto-categorization, priority recommendation).
-  - [ ] Evaluate AWS-native AI services (SageMaker, Bedrock, etc.) for integration.
-  - [ ] Outline a roadmap for transitioning to an AI-native application architecture.
-  - [ ] Draft an initial MLOps pipeline concept (CI/CD for ML).
-- **Estimated Size**: `L (4-8h / Research Task)`
+</div>

--- a/docs/observability_roadmap.md
+++ b/docs/observability_roadmap.md
@@ -1,3 +1,92 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# オブザーバビリティ（可観測性）実装ロードマップ
+
+本ドキュメントは、「My Roadmap」プロジェクトにおいてエンタープライズグレードのオブザーバビリティ（可観測性）を構築するための戦略的ロードマップです。ログ記録、モニタリング、分散トレーシング、および信頼性エンジニアリングの実践的スキルを習得するよう設計されています。
+
+---
+
+## 🏗️ Phase 1: 構造化ログ機能 (High-Cardinality Structured Logging)
+**目標**: 単純な `console.log` から、検索可能でハイパフォーマンスな JSON ログへ移行。
+
+### Issue 原案: `feat: implement structured logging with CloudWatch Insights support`
+- **背景**: 標準ログはフィルタリングが困難。CloudWatch での検索性を高めるため構造化ログが必要。
+- **タスク**:
+  - [ ] Next.js (Server Components/Actions) および Lambda 向けに `pino` を導入・設定。
+  - [ ] `web/src/lib/logger.ts` に統一されたロギングユーティリティを実装。
+  - [ ] 全ログに `request_id`, `user_id`, `correlation_id` を付与。
+  - [ ] CDK 経由で CloudWatch Groups のログ保持期間 (14日) を設定。
+- **習得スキル**:
+  - カーディナリティの高いデータの管理。
+  - CloudWatch Logs Insights のクエリ構文。
+  - 高トラフィックアプリにおけるロギングのパフォーマンスへの影響。
+
+---
+
+## 📈 Phase 2: リアルユーザーモニタリング (RUM) & パフォーマンス
+**目標**: サーバーの枠を超えてユーザー体験を可視化。
+
+### Issue 原案: `feat: integrate AWS CloudWatch RUM for client-side observability`
+- **背景**: ユーザーが遭遇する問題の多くはブラウザ側で発生。RUM により JS エラーやページロード時間を可視化。
+- **タスク**:
+  - [ ] AWS Console/CLI (または CDK) 経由で CloudWatch RUM App Monitor をプロビジョニング。
+  - [ ] Next.js `layout.tsx` に RUM スニペットを組み込み。
+  - [ ] 主要アクション (例: "タスク作成") にカスタムイベントを設定。
+  - [ ] Core Web Vitals (LCP, FID, CLS) を監視。
+- **習得スキル**:
+  - クライアント側のパフォーマンスメトリクス。
+  - プライバシーを保護したユーザーフローの追跡。
+  - クライアントエラーとサーバーレースの紐付け。
+
+---
+
+## 🔍 Phase 3: 分散トレーシング (Distributed Tracing)
+**目標**: エンドツーエンドのリクエストライフサイクルを可視化。
+
+### Issue 原案: `feat: enable distributed tracing with AWS X-Ray`
+- **背景**: どのコンポーネント (AppSync, Lambda, DynamoDB) がレイテンシーの原因となっているかを特定。
+- **タスク**:
+  - [ ] `web/amplify/backend.ts` 内の AppSync API および Lambda で X-Ray トレーシングを有効化。
+  - [ ] AWS X-Ray SDK を使用して特定ロジックブロックのサブセグメントを作成。
+  - [ ] CloudWatch Service Map 上でトレースをビジュアル表示。
+- **習得スキル**:
+  - トレースの伝播 (W3C Trace Context)。
+  - サーバーレスアーキテクチャにおけるボトルネックの特定。
+  - API レイテンシーのプロファイリング。
+
+---
+
+## 🛡️ Phase 4: サイト信頼性エンジニアリング (SLI/SLO)
+**目標**: 「正常」を定義し、「異常」時にアラートを発報。
+
+### Issue 原案: `feat: define SLIs/SLOs and implement CloudWatch Dashboards`
+- **背景**: サービスが不具合を起こしているタイミングを定量的に把握。
+- **タスク**:
+  - [ ] **SLI (サービスレベル指標)** の定義: API 成功率, P95 レイテンシー。
+  - [ ] **SLO (サービスレベル目標)** の設定: 99.9% 成功率。
+  - [ ] CloudWatch ダッシュボードの作成。
+  - [ ] 重大障害に対する複合アラートの設定。
+- **習得スキル**:
+  - SRE (Site Reliability Engineering) 原則。
+  - アラート疲労を避けるアクション可能なアラート設計。
+
+---
+
+## 📝 Issue 原案の活用方法
+1. 上記のタイトルと本文をコピー。
+2. 本リポジトリに新しい GitHub Issue を作成。
+3. 実装ステップをチェックリストとして活用し、順次対応。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Observability Implementation Roadmap
 
 This document outlines the strategic roadmap for implementing professional-grade observability in the **My Roadmap** project. These tasks are designed to build real-world skills in logging, monitoring, tracing, and reliability engineering.
@@ -76,3 +165,6 @@ This document outlines the strategic roadmap for implementing professional-grade
 2. Create a new GitHub Issue in this repository.
 3. Use the implementation steps as your checklist.
 4. Move from Phase 1 to Phase 4 sequentially for the best learning experience.
+
+</div>
+

--- a/docs/operations_policy.md
+++ b/docs/operations_policy.md
@@ -1,3 +1,74 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# AWS コスト設計および運用ポリシー (AWS Cost & Operations Policy)
+
+本ポリシーは、「My Roadmap」における AWS 運用コストの管理手順、リソースのクリーン状態保持（ハイジーン）、および事業継続性（DR/バックアップ）に関する運用指針を定めるものです。
+
+## 1. AWS 予算アラート (AWS Budget Alerts)
+
+予期せぬ請求を防ぐため、バックエンドの AWS CDK 経由で予算アラートが事前設定されています。
+
+| アラート名 | しきい値 (USD) | 判定基準タイプ | 状態 |
+| :--- | :--- | :--- | :--- |
+| **月間予算 (Monthly Budget)** | $5.00 | 実績 (100%) | **自動化 (CDK)** |
+| **予測アラート (Forecasted Alert)** | $5.00 | 予測 (100%) | **自動化 (CDK)** |
+
+### 設定構造 (自動化)
+アラートは `web/amplify/backend.ts` 内で `aws-cdk-lib/aws-budgets` を使用して定義されています。
+
+### 通知宛先 Eメールの設定手順
+通知用 Eメールアドレスは環境変数 **`BUDGET_NOTIFICATION_EMAIL`** から取得されます。
+
+**設定手順:**
+1. **AWS Amplify Console** にログイン。
+2. 対象アプリを選択 -> **App settings (アプリ設定)** -> **Environment variables (環境変数)**。
+3. **Manage variables (変数の管理)** をクリックし、以下を追加：
+   - 変数名: `BUDGET_NOTIFICATION_EMAIL`
+   - 値: `your-email@example.com`
+4. アプリケーションを再デプロイして変更を適用。
+
+---
+
+## 2. コストモニタリング戦略
+
+- **月次レビュー**: 毎月最初の月曜日に AWS Cost Explorer の月次レポートを確認。
+- **異常検知**: AppSync クエリ量や DynamoDB の読み書きキャパシティにおける異様なスパイクの有無を確認。
+- **リソースタグ付け**: コスト配分を追跡するため、すべてのプロジェクトリソースに `Project: MyRoadmap` タグを付与。
+
+## 3. リソース管理とクリーンネス (Hygiene)
+
+### CloudWatch ログ
+- **保持ポリシー**: Amplify/Lambda によって作成された全ロググループの保持期間を **14日** に設定。
+- **理由**: 標準ログはトラブルシューティングのみに必要なため、長期保存による不要なコストをカット。
+
+### データベース運用
+- **DynamoDB バックアップ**: 本番環境の `Task` テーブルに対して **Points-in-Time Recovery (PITR)** を有効化。
+- **クリーンアップ**: 未使用の S3 バケットや Amplify の検証用プレビューブランチを定期的に点検・削除。
+
+## 4. 障害復旧 (DR) およびバックアップ戦略
+
+| コンポーネント | 復旧戦略 | 目標復旧時点 (RPO) |
+| :--- | :--- | :--- |
+| **フロントエンド** | コードベース復旧 (GitHub Actions 再デプロイ) | < 1時間 |
+| **バックエンド API** | IaC 復旧 (Amplify Gen 2 / CDK) | < 1時間 |
+| **データベース** | DynamoDB PITR (継続的バックアップ) | 1秒 |
+
+### 復旧手順 (Disaster Recovery Procedure)
+リージョン障害または誤削除が発生した場合：
+1. `npx ampx pipeline-deploy` (または GitHub Actions) 経由でバックエンドを再デプロイ。
+2. AWS Console の Point-in-Time バックアップから最新の DynamoDB テーブルを復元。
+3. エンドポイント URL が変更された場合、フロントエンドの `amplify_outputs.json` を更新。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # AWS Cost Design and Operations Policy
 
 This policy outlines the procedures and configurations for managing AWS costs, resource hygiene, and business continuity for "My Roadmap".
@@ -55,3 +126,6 @@ In case of regional failure or accidental deletion:
 1. Re-deploy the backend using `npx ampx pipeline-deploy` (or via GitHub Actions).
 2. Restore the DynamoDB table from the latest Point-in-Time backup in the AWS Console.
 3. Update the `amplify_outputs.json` in the frontend if endpoint URLs change.
+
+</div>
+

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,51 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# プライバシーポリシー (Privacy Policy)
+
+最終更新日: 2026年8月2日
+
+## 概要
+当アプリケーションはユーザーのプライバシーを尊重します。パフォーマンスの監視およびユーザー体験向上のため、**AWS CloudWatch RUM** および **AWS X-Ray** を使用しています。
+
+## 収集するデータ
+以下の匿名テレメトリデータを収集します：
+- ページロード速度
+- クライアント側 JavaScript エラー
+- 匿名セッション識別子
+- ブラウザおよび端末タイプ
+
+### 収集しないデータ (DO NOT collect):
+- **個人識別情報 (PII)**: 氏名、メールアドレス、タスク内に含まれるデータ (タイトル、詳細等) は収集しません。
+- **フォーム入力内容**: フォームに入力されたテキスト情報は記録しません。
+- **機密データ**: トークンやIDの偶発的収集を防ぐため、URL パラメータはマスク処理されます。
+
+## ユーザーの選択肢 (オプトアウト)
+ユーザーは自身のデータに関して完全な制御権を持ちます。
+- **グローバルオプトアウト**: アプリケーション内の **設定 (Settings)** ページからいつでもアナリティクスを無効化できます。
+- **追跡防止**: オプトアウトした場合、ブラウザセッション内でトラッキングスクリプトは一切初期化されません。
+
+## データの利用目的
+収集されたデータは以下の目的でのみ使用されます：
+- アプリケーションクラッシュのデバッグ。
+- 低速なページロードの特定。
+- 将来の開発ロードマップに向けた利用傾向の把握。
+
+## お問い合わせ
+プライバシーに関するご質問がある場合は、リポジトリ管理者までお問い合わせください。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Privacy Policy
 
-Last updated: March 24, 2026
+Last updated: August 2, 2026
 
 ## Overview
 We value your privacy. This application uses **AWS CloudWatch RUM** and **AWS X-Ray** to monitor performance and improve user experience.
@@ -30,3 +75,6 @@ Collected data is used solely for:
 
 ## Contact
 If you have questions about our privacy practices, please contact the repository owner.
+
+</div>
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,3 +1,201 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# 要件定義書: My Roadmap
+
+## 1. プロジェクト概要
+
+**プロジェクト名:** My Roadmap  
+**目的:** ユーザーが自身の学習タスクを体系的に追跡・管理・整理するための学習タスク管理アプリケーション。
+
+**ターゲットユーザー:**
+
+- 自己主導型の学習目標を管理する個人ユーザー
+- スキル開発のために構造化されたタスク管理を必要とするユーザー
+
+---
+
+## 2. コア機能 (Phase 1 - MVP)
+
+### 2.1 学習タスク管理
+
+本アプリケーションの主要機能は、以下の必須属性を持つ学習タスクを管理することです：
+
+#### タスク属性仕様
+
+| 属性名 (Property) | データ型 | 必須 | 概要説明 |
+| :--- | :--- | :--- | :--- |
+| **タイトル (Title)** | String | はい | 学習タスクの名称 (例: "Next.js App Router の習得") |
+| **ステータス (Status)** | Enum | はい | タスクの進捗状態: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED` |
+| **優先度 (Priority)** | Enum | はい | 優先度レベル: `HIGH`, `MEDIUM`, `LOW` |
+| **期限 (Due Date)** | Date | はい | 完了目標日 |
+| **カテゴリ (Category)** | String | はい | 学習領域 (例: "フロントエンド", "バックエンド", "インフラ", "アルゴリズム") |
+
+#### ステータス定義
+
+- **NOT_STARTED**: タスクは作成されたが、まだ着手されていない状態
+- **IN_PROGRESS**: ユーザーが現在アクティブに取り組んでいる状態
+- **COMPLETED**: タスクが正常に完了した状態
+
+---
+
+## 3. 機能要件 (Functional Requirements)
+
+### 3.1 タスクの CRUD 操作
+
+- **FR-1.1**: ユーザーはすべての必須属性を指定して新しい学習タスクを作成できること。
+- **FR-1.2**: ユーザーはすべての学習タスク一覧を閲覧できること。
+- **FR-1.3**: ユーザーは既存タスクの任意の属性を更新できること。
+- **FR-1.4**: ユーザーは学習タスクを削除できること。
+- **FR-1.5**: ユーザーはタスクのステータスを変更できること (未着手 → 進行中 → 完了)。
+
+### 3.2 タスクのフィルタリングおよびソート
+
+- **FR-2.1**: ユーザーはステータス別にタスクをフィルタリングできること。
+- **FR-2.2**: ユーザーは優先度別にタスクをフィルタリングできること。
+- **FR-2.3**: ユーザーはカテゴリ別にタスクをフィルタリングできること。
+- **FR-2.4**: ユーザーは期限日順にタスクをソートできること。
+- **FR-2.5**: ユーザーは優先度順にタスクをソートできること。
+
+### 3.3 タスクの視覚的表示
+
+- **FR-3.1**: ユーザーにタスクのステータスが視覚的にわかりやすく表示されること。
+- **FR-3.2**: ユーザーに優先度インジケーター (カラーコード等) が表示されること。
+- **FR-3.3**: ユーザーに期日が近いタスクが強調表示されること。
+
+---
+
+## 4. 非機能要件 (Non-Functional Requirements)
+
+### 4.1 パフォーマンス要件
+
+- **NFR-1.1**: タスク一覧は 2 秒以内にロードされること。
+- **NFR-1.2**: タスクの CRUD 操作は 1 秒以内に完了すること。
+
+### 4.2 ユーザビリティ要件
+
+- **NFR-2.1**: UI はレスポンシブであり、デスクトップおよびモバイル端末で正常に動作すること。
+- **NFR-2.2**: UI はモダンなデザイン原則 (クリーン、直感的) に従うこと。
+- **NFR-2.3**: アクセシビリティに配慮されていること (WCAG 2.1 Level AA 準拠)。
+
+### 4.3 セキュリティ要件
+
+#### 4.3.1 認証・アイデンティティ管理
+
+- **NFR-3.1.1**: ユーザーは Eメール検証付きの AWS Cognito 経由で認証すること。
+- **NFR-3.1.2**: パスワードは以下の最小複雑性要件を満たすこと：
+  - 8 文字以上
+  - 英大文字 1 文字以上
+  - 英小文字 1 文字以上
+  - 数字 1 文字以上
+  - 記号 1 文字以上
+- **NFR-3.1.3**: JWT トークンは 1 時間の非アクティブで期限切れとなること。
+- **NFR-3.1.4**: リフレッシュトークンは httpOnly クッキーを使用して安全に保存されること。
+- **NFR-3.1.5**: ログイン失敗試行にはレート制限を設けること (15 分あたり最大 5 回)。
+
+#### 4.3.2 認可およびアクセス制御
+
+- **NFR-3.2.1**: ユーザーは自身のタスクにのみアクセスできること (`userId` による行レベルセキュリティの強制)。
+- **NFR-3.2.2**: すべての GraphQL ミューテーションは変更を許可する前にユーザーの所有権を検証すること。
+- **NFR-3.2.3**: AppSync リゾルバーはフィールドレベルで認可ルールを強制すること。
+- **NFR-3.2.4**: 有効な JWT トークンのない API リクエストは 401 Unauthorized を返すこと。
+- **NFR-3.2.5**: 未承認のリソースにアクセスしようとする API リクエストは 403 Forbidden を返すこと。
+
+#### 4.3.3 データ保護
+
+- **NFR-3.3.1**: 通信中のすべてのデータは TLS 1.2 以上で暗号化されること。
+- **NFR-3.3.2**: DynamoDB の保存データは AWS マネージドキーで暗号化されること。
+- **NFR-3.3.3**: 機密性の高いユーザーデータ (メールアドレス) はプレーンテキストでログに記録されないこと。
+
+#### 4.3.4 入力検証および API セキュリティ
+
+- **NFR-3.4.1**: すべてのユーザー入力はクライアント側・サーバー側の両方で検証・サニタイズされること。
+- **NFR-3.4.2**: GraphQL クエリの最大深度は 5 に制限されること。
+- **NFR-3.4.3**: API レート制限はユーザーあたり毎分 100 リクエストに設定されること。
+
+#### 4.3.5 セキュリティモニタリングおよびログ
+
+- **NFR-3.5.1**: 認証失敗の試行は CloudWatch にログ記録されること。
+- **NFR-3.5.2**: 不審なアクティビティは CloudWatch アラームをトリガーすること。
+- **NFR-3.5.3**: アクセスログは 90 日間保持されること。
+
+---
+
+## 5. クラウドアーキテクチャ要件 (AWS Amplify Gen 2)
+
+- **ARCH-1.1**: インフラストラクチャは TypeScript コード (AWS Amplify Gen 2 IaC) として定義・管理されること。
+- **ARCH-1.2**: バックエンドリソース (Cognito, DynamoDB, AppSync) は Amplify sandbox 環境でローカル検証可能であること。
+- **ARCH-1.3**: GitHub Actions CI/CD パイプライン経由で AWS Amplify ホスティング環境へ自動デプロイされること。
+
+---
+
+## 6. データモデル (Phase 1)
+
+### タスクエンティティ (Task Entity)
+
+```typescript
+interface Task {
+  id: string; // 一意識別子 (UUID)
+  userId: string; // タスク所有者ID (Cognitoより)
+  title: string; // タスク名
+  status: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+  priority: "HIGH" | "MEDIUM" | "LOW";
+  dueDate: string; // ISO 8601 日付フォーマット
+  category: string; // 学習領域
+  createdAt: string; // 作成日時
+  updatedAt: string; // 更新日時
+}
+```
+
+### DynamoDB テーブル設計
+
+- **テーブル名**: `Tasks`
+- **パーティションキー**: `userId` (String)
+- **ソートキー**: `id` (String)
+- **GSI (グローバルセカンダリインデックス)**:
+  - `StatusIndex`: パーティションキー = `userId`, ソートキー = `status`
+  - `DueDateIndex`: パーティションキー = `userId`, ソートキー = `dueDate`
+
+---
+
+## 7. ユーザーストーリー (User Stories)
+
+- **US-1**: 学習者として、学習したい内容を追跡できるように新しいタスクを作成したい。
+- **US-2**: 学習者として、ロードマップを一目で確認できるようにすべてのタスクを一覧で閲覧したい。
+- **US-3**: 学習者として、現在集中しているタスクがわかるように作業開始時にステータスを「進行中」に変更したい。
+- **US-4**: 学習者として、達成感を得るために完了したタスクを「完了」としてマークしたい。
+- **US-5**: 学習者として、重要なアイテムから着手できるように各タスクに優先度を設定したい。
+- **US-6**: 学習者として、時間を効率的に管理できるように期限日を設定したい。
+
+---
+
+## 8. スコープ外機能 (将来フェーズ)
+
+以下の機能は Phase 1 には含まれず、将来のイテレーションで検討されます：
+
+- サブタスク / 階層型タスク
+- 時間トラッキング (見積時間 vs 実績時間)
+- 学習リソースリンク (URL, メモ)
+- 進捗率表示 (%)
+- スキルツリー連携
+
+---
+
+## 9. ドキュメント情報
+
+- **バージョン**: 1.2.0
+- **最終更新日**: 2026-08-02
+- **ステータス**: 公開中
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Requirements Specification: My Roadmap
 
 ## 1. Project Overview
@@ -20,13 +218,13 @@ The primary feature of this application is to manage learning tasks with the fol
 
 #### Task Properties
 
-| Property     | Type   | Required | Description                                                                  |
-| ------------ | ------ | -------- | ---------------------------------------------------------------------------- |
-| **Title**    | String | Yes      | Name of the learning task (e.g., "Learn Next.js App Router")                 |
-| **Status**   | Enum   | Yes      | Current state of the task: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`         |
-| **Priority** | Enum   | Yes      | Task priority level: `HIGH`, `MEDIUM`, `LOW`                                 |
-| **Due Date** | Date   | Yes      | Target completion date                                                       |
-| **Category** | String | Yes      | Learning domain (e.g., "Frontend", "Backend", "Infrastructure", "Algorithm") |
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| **Title** | String | Yes | Name of the learning task (e.g., "Learn Next.js App Router") |
+| **Status** | Enum | Yes | Current state: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED` |
+| **Priority** | Enum | Yes | Priority level: `HIGH`, `MEDIUM`, `LOW` |
+| **Due Date** | Date | Yes | Target completion date |
+| **Category** | String | Yes | Learning domain (e.g., "Frontend", "Backend", "Infrastructure") |
 
 #### Status Definitions
 
@@ -103,202 +301,26 @@ The primary feature of this application is to manage learning tasks with the fol
 - **NFR-3.3.1**: All data in transit shall be encrypted using TLS 1.2 or higher
 - **NFR-3.3.2**: DynamoDB data at rest shall be encrypted using AWS managed keys
 - **NFR-3.3.3**: Sensitive user data (email addresses) shall not be logged in plain text
-- **NFR-3.3.4**: User passwords shall never be stored in plain text (handled by Cognito)
-- **NFR-3.3.5**: JWT tokens shall not be stored in localStorage (use httpOnly cookies)
 
 #### 4.3.4 Input Validation & API Security
 
 - **NFR-3.4.1**: All user inputs shall be validated and sanitized on both client and server side
 - **NFR-3.4.2**: GraphQL queries shall have a maximum depth limit of 5 to prevent DoS attacks
 - **NFR-3.4.3**: API rate limiting shall be enforced at 100 requests per minute per user
-- **NFR-3.4.4**: CORS policy shall restrict allowed origins to the production domain only
-- **NFR-3.4.5**: GraphQL schema shall validate input types and reject malformed requests
-- **NFR-3.4.6**: File uploads shall not be allowed in Phase 1 (future consideration)
 
 #### 4.3.5 Security Monitoring & Logging
 
 - **NFR-3.5.1**: Failed authentication attempts shall be logged to CloudWatch
 - **NFR-3.5.2**: Suspicious activity (rate limit exceeded, invalid tokens) shall trigger CloudWatch alarms
 - **NFR-3.5.3**: Access logs shall be retained for 90 days
-- **NFR-3.5.4**: Security events (failed auth, authorization failures) shall be monitored and dashboarded
-- **NFR-3.5.5**: Application logs shall not contain sensitive data (passwords, tokens, PII)
-
-#### 4.3.6 Compliance & Best Practices
-
-- **NFR-3.6.1**: Application shall follow OWASP Top 10 mitigation strategies
-- **NFR-3.6.2**: Dependencies shall be scanned for known vulnerabilities using `npm audit`
-- **NFR-3.6.3**: AWS resources shall follow the principle of least privilege (IAM policies)
-- **NFR-3.6.4**: Security headers shall be configured:
-  - `Strict-Transport-Security` (HSTS)
-  - `X-Frame-Options: DENY`
-  - `X-Content-Type-Options: nosniff`
-  - `Content-Security-Policy` (CSP)
-- **NFR-3.6.5**: Regular security reviews shall be conducted before each release
-
-**Note**: Advanced security features (MFA, AWS WAF, AWS GuardDuty) are deferred to Phase 2+ for cost optimization.
-
-### 4.4 Scalability
-
-- **NFR-4.1**: System shall support up to 1,000 tasks per user
-- **NFR-4.2**: System shall handle concurrent users efficiently
 
 ---
 
-## 5. System Architecture
+## 5. Cloud Architecture Requirements (AWS Amplify Gen 2)
 
-### 5.1 Infrastructure Architecture
-
-The following diagram illustrates the AWS infrastructure and service integration:
-
-```mermaid
-graph TB
-    subgraph "Client Layer"
-        Browser[Web Browser]
-    end
-
-    subgraph "AWS Cloud"
-        subgraph "Frontend Hosting"
-            Amplify[AWS Amplify Hosting]
-            CloudFront[Amazon CloudFront CDN]
-        end
-
-        subgraph "Authentication"
-            Cognito[Amazon Cognito]
-        end
-
-        subgraph "API Layer"
-            AppSync[AWS AppSync<br/>GraphQL API]
-        end
-
-        subgraph "Data Layer"
-            DynamoDB[(Amazon DynamoDB)]
-        end
-
-        subgraph "CI/CD"
-            GitHub[GitHub Repository]
-            Actions[GitHub Actions]
-        end
-    end
-
-    Browser -->|HTTPS| CloudFront
-    CloudFront --> Amplify
-    Browser -->|Auth Request| Cognito
-    Browser -->|GraphQL Query/Mutation| AppSync
-    AppSync -->|Verify Token| Cognito
-    AppSync -->|Read/Write| DynamoDB
-
-    GitHub -->|Push| Actions
-    Actions -->|Deploy| Amplify
-
-    style Browser fill:#e1f5ff
-    style Amplify fill:#ff9900
-    style CloudFront fill:#ff9900
-    style Cognito fill:#ff9900
-    style AppSync fill:#ff9900
-    style DynamoDB fill:#ff9900
-    style GitHub fill:#24292e
-    style Actions fill:#2088ff
-```
-
-### 5.2 Application Architecture
-
-The following diagram shows the application layer structure:
-
-```mermaid
-graph TB
-    subgraph "Frontend - Next.js App Router"
-        Pages[Pages/Routes]
-        Components[React Components<br/>shadcn/ui]
-        GraphQLClient[Apollo Client /<br/>AWS Amplify Client]
-        AuthContext[Auth Context]
-    end
-
-    subgraph "Backend - AWS AppSync"
-        Schema[GraphQL Schema]
-        Resolvers[Resolvers]
-        AuthZ[Authorization Rules]
-    end
-
-    subgraph "Data Store"
-        TasksTable[Tasks Table<br/>DynamoDB]
-    end
-
-    Pages --> Components
-    Components --> GraphQLClient
-    Components --> AuthContext
-    GraphQLClient -->|GraphQL Operations| Schema
-    Schema --> Resolvers
-    Resolvers --> AuthZ
-    AuthZ -->|Validated Request| TasksTable
-
-    style Pages fill:#61dafb
-    style Components fill:#61dafb
-    style GraphQLClient fill:#61dafb
-    style AuthContext fill:#61dafb
-    style Schema fill:#e535ab
-    style Resolvers fill:#e535ab
-    style AuthZ fill:#e535ab
-    style TasksTable fill:#4053d6
-```
-
-### 5.3 Data Flow Diagram
-
-The following diagram illustrates a typical user interaction flow:
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Browser
-    participant Cognito
-    participant AppSync
-    participant DynamoDB
-
-    User->>Browser: Open Application
-    Browser->>Cognito: Request Authentication
-    Cognito-->>Browser: Return JWT Token
-
-    User->>Browser: Create Task
-    Browser->>AppSync: GraphQL Mutation<br/>(with JWT)
-    AppSync->>Cognito: Validate Token
-    Cognito-->>AppSync: Token Valid
-    AppSync->>AppSync: Check Authorization
-    AppSync->>DynamoDB: PutItem (Task)
-    DynamoDB-->>AppSync: Success
-    AppSync-->>Browser: Task Created
-    Browser-->>User: Display Success
-
-    User->>Browser: View Task List
-    Browser->>AppSync: GraphQL Query<br/>(with JWT)
-    AppSync->>Cognito: Validate Token
-    Cognito-->>AppSync: Token Valid
-    AppSync->>DynamoDB: Query (userId)
-    DynamoDB-->>AppSync: Return Tasks
-    AppSync-->>Browser: Task List
-    Browser-->>User: Display Tasks
-```
-
----
-
-## 6. Technical Stack
-
-### Frontend
-
-- **Framework**: Next.js (App Router)
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS
-- **UI Components**: shadcn/ui
-
-### Backend
-
-- **Infrastructure**: AWS Amplify Gen 2 (TypeScript-based IaC)
-- **Authentication**: AWS Cognito
-- **Database**: Amazon DynamoDB
-- **API**: AWS AppSync (GraphQL)
-
-### CI/CD
-
-- **Version Control**: GitHub
-- **Pipeline**: GitHub Actions
+- **ARCH-1.1**: Infrastructure shall be defined and managed as TypeScript code (AWS Amplify Gen 2 IaC)
+- **ARCH-1.2**: Backend resources (Cognito, DynamoDB, AppSync) shall be verifiable locally in Amplify sandbox
+- **ARCH-1.3**: Automated deployment to AWS Amplify Hosting via GitHub Actions CI/CD pipeline
 
 ---
 
@@ -333,23 +355,12 @@ interface Task {
 
 ## 7. User Stories (Phase 1)
 
-### Epic: Task Management
-
-**US-1**: As a learner, I want to create a new learning task so that I can track what I need to study.
-
-**US-2**: As a learner, I want to view all my tasks in a list so that I can see my learning roadmap at a glance.
-
-**US-3**: As a learner, I want to update a task's status to "In Progress" when I start working on it, so that I can track my current focus.
-
-**US-4**: As a learner, I want to mark a task as "Completed" when I finish it, so that I can see my progress.
-
-**US-5**: As a learner, I want to set a priority for each task so that I can focus on the most important items first.
-
+**US-1**: As a learner, I want to create a new learning task so that I can track what I need to study.  
+**US-2**: As a learner, I want to view all my tasks in a list so that I can see my learning roadmap at a glance.  
+**US-3**: As a learner, I want to update a task's status to "In Progress" when I start working on it, so that I can track my current focus.  
+**US-4**: As a learner, I want to mark a task as "Completed" when I finish it, so that I can see my progress.  
+**US-5**: As a learner, I want to set a priority for each task so that I can focus on the most important items first.  
 **US-6**: As a learner, I want to set a due date for each task so that I can manage my time effectively.
-
-**US-7**: As a learner, I want to filter tasks by status so that I can focus on tasks that are in progress or not yet started.
-
-**US-8**: As a learner, I want to categorize tasks (Frontend, Backend, etc.) so that I can organize my learning by domain.
 
 ---
 
@@ -357,82 +368,19 @@ interface Task {
 
 The following features are **not included in Phase 1** but may be considered for future iterations:
 
-**Task Management Features:**
-
 - Subtasks / nested tasks
 - Time tracking (estimated hours, actual hours)
 - Learning resources (URLs, notes)
 - Progress percentage
-- Achievement tracking
-- Collaboration features
 - Skill tree integration
-- Difficulty levels
-- Tags and advanced search
-- Analytics and insights
-
-**Advanced Security Features (Phase 2+):**
-
-- Multi-Factor Authentication (MFA)
-- AWS WAF (Web Application Firewall)
-- AWS GuardDuty (threat detection)
-- Advanced DDoS protection
-- Penetration testing
-- Security incident response automation
 
 ---
 
-## 9. Success Criteria
+## 9. Document Information
 
-Phase 1 will be considered successful when:
-
-1. Users can perform full CRUD operations on learning tasks
-2. Users can filter and sort tasks by status, priority, category, and due date
-3. The application is deployed on AWS with authentication
-4. The UI is responsive and follows modern design standards
-5. All core functional requirements (FR-1.x, FR-2.x, FR-3.x) are implemented
-6. The codebase follows TypeScript best practices and maintains type safety
-
----
-
-## 10. Acceptance Criteria
-
-### Functional Criteria
-
-- [x] User can sign up and log in via AWS Cognito
-- [x] User can create a task with title, status, priority, due date, and category
-- [x] User can view a list of all their tasks
-- [x] User can edit any task property
-- [x] User can delete a task
-- [x] User can change task status (NOT_STARTED → IN_PROGRESS → COMPLETED)
-- [x] User can filter tasks by status, priority, and category
-- [x] User can sort tasks by due date and priority
-- [x] UI is responsive on desktop and mobile
-- [x] Application is deployed to AWS and accessible via HTTPS
-- [x] Code follows TypeScript best practices and includes type safety
-- [x] README includes setup instructions and project overview
-
-### Security Criteria
-
-- [ ] Password complexity requirements are enforced during registration
-- [ ] Email verification is required before first login
-- [ ] JWT tokens expire after 1 hour of inactivity
-- [ ] Users cannot access other users' tasks (verified via API testing)
-- [ ] API requests without valid JWT return 401 Unauthorized
-- [ ] All data is transmitted over HTTPS (TLS 1.2+)
-- [ ] DynamoDB encryption at rest is enabled
-- [ ] GraphQL query depth limiting is configured (max depth 5)
-- [ ] API rate limiting prevents abuse (100 requests/min per user)
-- [ ] CORS policy restricts to production domain only
-- [ ] Security headers are configured (HSTS, X-Frame-Options, CSP, X-Content-Type-Options)
-- [ ] npm audit shows no high or critical vulnerabilities
-- [ ] Failed authentication attempts are logged to CloudWatch
-- [ ] CloudWatch alarms are configured for suspicious activity
-
----
-
-## Document Information
-
-- **Version**: 1.1.0
-- **Last Updated**: 2026-03-16
+- **Version**: 1.2.0
+- **Last Updated**: 2026-08-02
 - **Author**: John ([github](https://github.com/vanilla2412))
 - **Status**: Published
+
+</div>

--- a/docs/setup-amplify-hosting.md
+++ b/docs/setup-amplify-hosting.md
@@ -1,3 +1,48 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# AWS Amplify ホスティングおよびベーシック認証セットアップ手順 (AWS Amplify Hosting Setup)
+
+本ガイドは、Next.js フロントエンドおよび Amplify Gen 2 バックエンドを AWS Amplify ホスティング経由でデプロイし、ベーシック認証（Basic Authentication）で保護する手順をまとめたものです。
+
+## 1. AWS Amplify へのリポジトリ接続
+
+1. AWS マネジメントコンソールにログインし、**AWS Amplify** に移動します。
+2. **新しいアプリを作成 (Create new app)** または **アプリをデプロイ** をクリック。
+3. **GitHub** を選択し、AWS Amplify にリポジトリへのアクセス権限を授与します。
+4. 対象リポジトリ (`anti00`) および対象ブランチ (`main`) を選択。
+5. ビルド設定にて、Amplify がルートディレクトリにある `amplify.yml` を自動検出することを確認。
+6. フロントエンドと共にバックエンドリソースをデプロイするオプションを選択し、適切な IAM サービスロールを割り当てます。
+7. **保存してデプロイ** をクリックし、ビルド・デプロイの完了を待ちます。
+
+## 2. ベーシック認証 (アクセス制御) の設定
+
+開発段階での一般公開を防ぐため、アクセス制御を有効化します。
+
+1. AWS Amplify Console にて作成したアプリを開きます。
+2. 左サイドバーから **ホスティング (Hosting)** > **アクセス制御 (Access control)** をクリック。
+3. **アクセス管理 (Manage access)** をクリック。
+4. アクセス設定を「一般公開 (Publicly viewable)」から **「アクセス制限 (Restrict access)」** に変更。
+5. 認証用の **ユーザー名 (Username)** と **パスワード (Password)** を入力。
+6. **保存 (Save)** をクリック。
+
+## 3. 動作検証 (Verification)
+
+1. 設定保存後、発行されたライブ URL (`https://main.xxxxxx.amplifyapp.com`) にアクセス。
+2. ブラウザがユーザー名とパスワードの入力を求めてくることを確認。
+3. 設定した資格情報を入力し、ログイン後に以下を確認：
+   - タスクダッシュボードが正常にロードされること。
+   - Cognito による認証および AppSync/Amplify Data API 経由のデータ取得が正常に動作すること。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # AWS Amplify Hosting & Basic Authentication Setup
 
 This guide details how to deploy the Next.js frontend and Amplify Gen 2 backend via AWS Amplify Hosting and secure it using Basic Authentication. This fulfills the requirements of Issue #35.
@@ -33,3 +78,6 @@ To prevent unauthorized public access to the MVP during development, you must en
    - The Task Dashboard loads correctly.
    - Protected Next.js routes operate as expected.
    - You can log in with Cognito and fetch data through the AppSync/Amplify Data API.
+
+</div>
+

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,3 +1,91 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# アプリケーションショーケース (Application Showcase)
+
+**My Roadmap** アプリケーションに実装されているユーザーインターフェース、UXフロー、およびコア機能の概要です。
+
+🎥 **[デモ動画 (AIエージェント統合デモ)](https://youtu.be/CB09PKJzTkc)**
+
+[![デモ動画](https://img.youtube.com/vi/CB09PKJzTkc/0.jpg)](https://youtu.be/CB09PKJzTkc)
+
+---
+
+## 1. 認証フロー (Authentication Flow)
+**AWS Cognito** を活用したセキュアなユーザーアイデンティティ管理機能。
+
+### 主な特徴
+* **デュアルタブインターフェース**: 「サインイン (Sign In)」と「アカウント作成 (Create Account)」をシームレスに切り替えるインターフェース。
+* **パスワード表示トグル**: パスワード入力を確認できるインラインの目のアイコン。
+* **入力バリデーションと安全機構**: ガイドテキストやエラーメッセージを備えたクリーンな入力レイアウト。
+* **セルフサービスアクション**: パスワード再設定 (Forgot your password?) へのアクセス機能。
+
+### スクリーンショット
+
+<div style="display: flex; gap: 16px; flex-wrap: wrap;">
+  <div style="flex: 1; min-width: 300px;">
+    <p style="font-weight: 600; text-align: center;">サインイン画面</p>
+    <img src="/assets/showcase/auth-signin.png" alt="サインイン画面" style="border-radius: 8px; border: 1px solid var(--vp-c-divider); box-shadow: 0 4px 12px rgba(0,0,0,0.1); width: 100%; height: auto;" />
+  </div>
+  <div style="flex: 1; min-width: 300px;">
+    <p style="font-weight: 600; text-align: center;">アカウント作成画面</p>
+    <img src="/assets/showcase/auth-signup.png" alt="アカウント作成画面" style="border-radius: 8px; border: 1px solid var(--vp-c-divider); box-shadow: 0 4px 12px rgba(0,0,0,0.1); width: 100%; height: auto;" />
+  </div>
+</div>
+
+---
+
+## 2. タスクダッシュボード (Task Dashboard)
+タスク一覧、メタデータ表示、高度な検索・フィルタリング機能を備えたメインコントロールセンター。
+
+### 主な特徴
+* **詳細タスクカード**: タイトル、詳細要約、優先度バッジ (`LOW` / `MEDIUM` / `HIGH`)、期限、ステータスバッジ (`TODO`, `IN PROGRESS`, `DONE`) を一目で確認。
+* **マルチ条件フィルタリング**: ステータス、優先度、カテゴリ、タグによる動的なタスク抽出。
+* **ソート機能**: 期限日や優先順位による柔軟な一覧ソート。
+* **トースト通知**: タスク更新時に画面右下に即座にフィードバックを表示する非同期トースト通知。
+
+### スクリーンショット
+
+<img src="/assets/showcase/dashboard.png" alt="タスクダッシュボード画面" style="border-radius: 8px; border: 1px solid var(--vp-c-divider); box-shadow: 0 4px 12px rgba(0,0,0,0.1); margin: 1.5rem 0; width: 100%; height: auto;" />
+
+---
+
+## 3. タスク作成および編集 (Task Creation & Editing)
+詳細なパラメータを指定して新規タスクの作成および編集を行うモーダルダイアログ。
+
+### 主な特徴
+* **時間管理**: `見積時間 (Estimated Hours)` と `実績時間 (Actual Hours)` を追跡。
+* **期限日ピッカー**: 完了目標日を設定するためのネイティブカレンダー選択ツール。
+* **タグ & カテゴリ**: 学習領域カテゴリとカンマ区切りのカスタムタグによる整理。
+* **動的サブタスクリスト**: 1つの親タスク内で複数のサブタスクを追加・削除・管理。
+
+### スクリーンショット
+
+<img src="/assets/showcase/task-edit.png" alt="タスク作成・編集モーダル" style="border-radius: 8px; border: 1px solid var(--vp-c-divider); box-shadow: 0 4px 12px rgba(0,0,0,0.1); margin: 1.5rem 0; width: 100%; height: auto;" />
+
+---
+
+## 4. 設定およびアカウントプロファイル (Settings & Account Profile)
+ユーザー情報の更新、プライバシー設定、アカウント削除を行う中央設定領域。
+
+### 主な特徴
+* **プロファイル要約**: サインイン中のユーザーの基本情報 (Eメールアドレス等) を表示。
+* **プライバシーコントロール**: アナリティクスおよびテレメトリ計測のオン/オフ切り替えスイッチ。
+* **デンジャーゾーン (Danger Zone)**: 誤操作による削除を防ぐチェックボックス同意付きのアカウント解約・データ削除フロー。
+
+### スクリーンショット
+
+<img src="/assets/showcase/settings.png" alt="アカウント設定画面" style="border-radius: 8px; border: 1px solid var(--vp-c-divider); box-shadow: 0 4px 12px rgba(0,0,0,0.1); margin: 1.5rem 0; width: 100%; height: auto;" />
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Application Showcase
 
 An overview of the current user interface, user experience flows, and core features implemented in the **My Roadmap** application.
@@ -73,3 +161,6 @@ A centralized preferences area for user profile updates, privacy control, and ac
 ### Screenshots
 
 <img src="/assets/showcase/settings.png" alt="Account Settings Screen" style="border-radius: 8px; border: 1px solid var(--vp-c-divider); box-shadow: 0 4px 12px rgba(0,0,0,0.1); margin: 1.5rem 0; width: 100%; height: auto;" />
+
+</div>
+

--- a/docs/test_strategy.md
+++ b/docs/test_strategy.md
@@ -1,3 +1,79 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# テスト戦略および不具合管理ドキュメント
+
+本ドキュメントは、「My Roadmap」プロジェクトにおけるテスト手法、品質基準、および自律型AIエンジニアリングループ（Vitest統合）を定義します。
+
+---
+
+## 1. テスト戦略 (Testing Strategy)
+
+本プロジェクトではテストピラミッドアプローチを採用し、高速で信頼性の高い単体テストおよびコンポーネントテストを重視します。
+
+### 1.1 テストレベル定義
+
+| レベル | 測定対象スコープ | 使用ツール | 実行頻度 |
+| :--- | :--- | :--- | :--- |
+| **単体テスト (Unit Test)** | 純粋関数、カスタムHook、ユーティリティロジック | Vitest | PR作成時 / ローカル開発時 |
+| **コンポーネントテスト** | UIコンポーネント (shadcn/ui), フォーム操作 | Vitest + React Testing Library | PR作成時 / ローカル開発時 |
+| **統合テスト (Integration)** | Amplify GraphQL API, 認証フロー | 手動 (Amplify Sandbox) | 主要機能の更新時 |
+| **E2Eテスト** | フルユーザーフロー | Playwright (将来導入) | MVPリリース後 |
+
+### 1.2 チームおよびAIの役割分担
+
+- **開発者 (Developers)**: 新機能追加時に単体テストおよびコンポーネントテストを作成する責任を負います。
+- **AIエージェント**: テスト基盤の維持、自律型TDDループの駆動、および初回テストコード雛形の自動生成を担当します。
+
+---
+
+## 2. 不具合管理 (Defect Management)
+
+### 2.1 Issueトラッキングの運用
+- すべてのバグは `bug` ラベルを付与して GitHub Issues に報告されます。
+- 報告には以下を含める必要があります：
+  - 再現手順 (Steps to reproduce)
+  - 期待される動作 vs 実際の動作
+  - 実行環境情報 (ブラウザ、OS)
+
+### 2.2 優先度（重要度）定義
+
+| レベル | 概要説明 | 対応優先度 |
+| :--- | :--- | :--- |
+| **P0 (最重要/Critical)** | 核心機能の破損 (認証、DB接続異常)、セキュリティ漏洩 | 即時修正 |
+| **P1 (重要/High)** | 主要機能の欠損、UI/UXの深刻な阻害 | 次回スプリント |
+| **P2 (中度/Medium)** | 軽微な機能バグ、エッジケースの問題 | 計画順次対応 |
+| **P3 (低度/Low)** | スタイル崩れ、軽微な誤字 | バックログ |
+
+---
+
+## 3. 開発ツールおよびテスト環境
+
+- **テストランナー**: [Vitest](https://vitest.dev/) (`cd web && npx vitest run`)
+- **実行環境**: [jsdom](https://github.com/jsdom/jsdom)
+- **コンポーネントモック**: [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
+- **カバレッジ計測**: Vitest Coverage (`cd web && npx vitest run --coverage`) — 最低 **80%** のカバレッジ基準。
+- **CI/CD統合**: GitHub Actions により `main` へのPRごとに自動テストを実行。
+
+---
+
+## 4. AIエージェントとのテスト連携 (AI Agent & Testing)
+
+本プロジェクトでは、AIエージェントによる自動開発ループ (`/loop-engineering`) 内で Vitest が単体・コンポーネントテストの核心的な検証エンジンとして機能します。
+
+- **TDD ガードレール**: AIエージェントは新機能追加時に必ず Vitest テストを先に記述 (RED) し、失敗を確認した後に最小限の実装 (GREEN) を行います。
+- **品質・カバレッジゲート**: PR 生成前に全テストの自動実行とカバレッジ監査（80%以上必須、認証・セキュリティは100%）が強制されます。
+- **自律開発アーキテクチャ詳細**: AIエージェントの自律開発ループ全般や AI Engineering OS の詳細設計については、[AI開発ガイドライン (/ai_development_guidelines)](/ai_development_guidelines) を参照してください。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Test Strategy and Defect Management
 
 This document defines the testing approach, quality standards, and autonomous AI engineering loop integration for the "My Roadmap" project.
@@ -54,36 +130,13 @@ We follow the testing pyramid approach, prioritizing unit and integration tests 
 
 ---
 
-## 4. Autonomous AI Engineering Loop & Vitest Integration
+## 4. AI Agent & Testing Integration
 
-The project incorporates an **Agent-First Engineering Operating System** comprising 7 composable workflow modules. Vitest serves as the core verification and TDD engine within this autonomous architecture.
+In this project, Vitest serves as the core verification engine within the autonomous AI execution loop (`/loop-engineering`).
 
-```mermaid
-graph TD
-    PE["Prompt Engineering"] --> CE["Context Engineering"]
-    CE --> PL["Planning Engineering"]
-    PL --> LE["Loop Engineering (Vitest TDD)"]
-    LE <--> HE["Harness Engineering (Vitest Execution)"]
-    LE --> VE["Verification Engineering (Quality Gate)"]
-    VE --> PRE["PR Engineering"]
-```
+- **TDD Guardrails**: The AI agent is required to write failing tests first (RED) before implementing functional code (GREEN).
+- **Quality & Coverage Gates**: Automated full test execution and coverage audits (80%+ threshold required, 100% for auth/security) are enforced before PR generation.
+- **Detailed Guidelines**: For full specifications on the autonomous loop architecture and AI Engineering OS, refer to the [AI Development Guidelines](/ai_development_guidelines).
 
-### 4.1 Vitest-Powered TDD Execution Cycle (`/loop-engineering`)
+</div>
 
-Autonomous AI agents execute code modifications following a strict Test-Driven Development (TDD) cycle driven by Vitest:
-
-1. **RED Phase (Failing Test First)**:
-   - The agent writes or updates unit/component tests covering target requirements.
-   - Vitest is executed via **Harness Engineering** (`.agent/workflows/harness-engineering.md`) running `cd web && npx vitest run` to confirm the test **FAILS** as expected.
-2. **GREEN Phase (Minimal Implementation)**:
-   - The agent implements the minimal production code necessary to pass the failing test.
-   - Vitest is re-run to confirm the test **PASSES**.
-3. **REFACTOR Phase**:
-   - Code is cleaned, modularized, and checked for immutability while keeping Vitest tests green.
-
-### 4.2 Automated Verification & Quality Gates (`/verification-engineering`)
-
-Before any Pull Request is generated:
-- **Full Test Suite Execution**: Vitest runs all unit and component tests.
-- **Coverage Audit**: Vitest coverage must meet or exceed **80%** (100% required for security and authentication logic).
-- **Circuit Breaker Policy**: If a test failure persists after **3 consecutive self-correction retries**, the agent halts execution, reverts to the last git checkpoint (`git checkout -- .`), and alerts the human developer.

--- a/docs/test_strategy.md
+++ b/docs/test_strategy.md
@@ -1,6 +1,8 @@
 # Test Strategy and Defect Management
 
-This document defines the testing approach and quality standards for the "My Roadmap" project.
+This document defines the testing approach, quality standards, and autonomous AI engineering loop integration for the "My Roadmap" project.
+
+---
 
 ## 1. Testing Strategy
 
@@ -18,7 +20,9 @@ We follow the testing pyramid approach, prioritizing unit and integration tests 
 ### 1.2 Responsibilities
 
 - **Developers**: Responsible for writing unit and component tests for every new feature.
-- **AI Agent**: Responsible for maintaining test infrastructure and generating initial test boilerplate.
+- **AI Agent**: Responsible for maintaining test infrastructure, driving autonomous TDD loops, and generating initial test boilerplate.
+
+---
 
 ## 2. Defect Management
 
@@ -38,9 +42,48 @@ We follow the testing pyramid approach, prioritizing unit and integration tests 
 | **P2 (Medium)** | Minor feature bug, edge case issues | As scheduled |
 | **P3 (Low)** | Stylistic issues, minor typos | Backlog |
 
+---
+
 ## 3. Tooling and Environment
 
-- **Runner**: [Vitest](https://vitest.dev/)
+- **Runner**: [Vitest](https://vitest.dev/) (`cd web && npx vitest run`)
 - **Environment**: [jsdom](https://github.com/jsdom/jsdom)
 - **Component Mocking**: [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
-- **CI Integration**: GitHub Actions runs `npm run test` on every PR to `main`.
+- **Coverage Tool**: Vitest Coverage (`cd web && npx vitest run --coverage`) — Minimum 80% threshold required.
+- **CI Integration**: GitHub Actions runs unit tests on every PR to `main`.
+
+---
+
+## 4. Autonomous AI Engineering Loop & Vitest Integration
+
+The project incorporates an **Agent-First Engineering Operating System** comprising 7 composable workflow modules. Vitest serves as the core verification and TDD engine within this autonomous architecture.
+
+```mermaid
+graph TD
+    PE["Prompt Engineering"] --> CE["Context Engineering"]
+    CE --> PL["Planning Engineering"]
+    PL --> LE["Loop Engineering (Vitest TDD)"]
+    LE <--> HE["Harness Engineering (Vitest Execution)"]
+    LE --> VE["Verification Engineering (Quality Gate)"]
+    VE --> PRE["PR Engineering"]
+```
+
+### 4.1 Vitest-Powered TDD Execution Cycle (`/loop-engineering`)
+
+Autonomous AI agents execute code modifications following a strict Test-Driven Development (TDD) cycle driven by Vitest:
+
+1. **RED Phase (Failing Test First)**:
+   - The agent writes or updates unit/component tests covering target requirements.
+   - Vitest is executed via **Harness Engineering** (`.agent/workflows/harness-engineering.md`) running `cd web && npx vitest run` to confirm the test **FAILS** as expected.
+2. **GREEN Phase (Minimal Implementation)**:
+   - The agent implements the minimal production code necessary to pass the failing test.
+   - Vitest is re-run to confirm the test **PASSES**.
+3. **REFACTOR Phase**:
+   - Code is cleaned, modularized, and checked for immutability while keeping Vitest tests green.
+
+### 4.2 Automated Verification & Quality Gates (`/verification-engineering`)
+
+Before any Pull Request is generated:
+- **Full Test Suite Execution**: Vitest runs all unit and component tests.
+- **Coverage Audit**: Vitest coverage must meet or exceed **80%** (100% required for security and authentication logic).
+- **Circuit Breaker Policy**: If a test failure persists after **3 consecutive self-correction retries**, the agent halts execution, reverts to the last git checkpoint (`git checkout -- .`), and alerts the human developer.

--- a/docs/troubleshooting-cognito.md
+++ b/docs/troubleshooting-cognito.md
@@ -1,8 +1,62 @@
+<script setup>
+import { useLanguage } from './.vitepress/theme/composables/useLanguage'
+
+const { currentLang } = useLanguage()
+</script>
+
+<div v-if="currentLang === 'ja'" class="lang-content ja-content">
+
+# AWS Cognito User Pool 表示ミスマッチのトラブルシューティング
+
+## 背景・概要
+
+`npx ampx sandbox` を使用してローカル開発を行っている際、アプリ上で作成したユーザーが AWS Cognito コンソールに表示されない、または User Pool のユーザー数が 0 と表示される現象が発生することがあります。これは通常、コンソール側で異なる AWS アカウント、リージョン、あるいは別の sandbox インスタンスを参照していることが原因です。
+
+## 確認・検証手順
+
+### 1. ローカルの AWS アイデンティティを確認する
+
+ローカル開発環境がどのアカウントおよびリージョンをターゲットにしているか確認します。ターミナルで以下を実行します：
+
+```bash
+aws sts get-caller-identity
+aws configure get region
+```
+
+1つ目のコマンドの `Account` ID および 2つ目のコマンドのリージョンが、AWS Console でログインしているアカウントおよびリージョンと一致していることを確認してください。
+
+### 2. アクティブな User Pool ID を特定する
+
+アプリケーションが現在使用している正確な User Pool ID は Amplify によって動的に生成され、`amplify_outputs.json` ファイルに保存されています。
+
+`web/amplify_outputs.json` を開き、`auth.user_pool_id` プロパティを確認します。
+
+```json
+{
+  "auth": {
+    "user_pool_id": "ap-northeast-1_xxxxxxxxx"
+  }
+}
+```
+
+### 3. コンソール上で正しい User Pool を確認する
+
+1. ステップ 1 で確認したアカウント ID で AWS マネジメントコンソールにログイン。
+2. コンソールのリージョンを正しいリージョン (例: `ap-northeast-1`) に切り替え。
+3. **Amazon Cognito** > **ユーザープール (User Pools)** に移動。
+4. ステップ 2 で確認した正確な User Pool ID を検索して確認。
+
+該当する User Pool ID が見つからない場合は、過去の古い sandbox や他の開発者の sandbox インスタンスを参照していないか確認してください。Amplify sandbox は、PC のユーザー名 (例: `amplify-admin` やローカルユーザー名) ごとにリソースを分離します。
+
+</div>
+
+<div v-if="currentLang === 'en'" class="lang-content en-content">
+
 # Troubleshooting AWS Cognito User Pool Visibility Mismatch
 
 ## Context
 
-When running local development with \`npx ampx sandbox\`, you may find that users created in your local app don't appear in the AWS Cognito Console, or the User Pool seems to have 0 users. This typically happens because the console is looking at the wrong Account, Region, or Sandbox instance.
+When running local development with `npx ampx sandbox`, you may find that users created in your local app don't appear in the AWS Cognito Console, or the User Pool seems to have 0 users. This typically happens because the console is looking at the wrong Account, Region, or Sandbox instance.
 
 ## Verification Steps
 
@@ -10,33 +64,35 @@ When running local development with \`npx ampx sandbox\`, you may find that user
 
 Check which AWS account and Region your local development is targeting. Open your terminal and run:
 
-\`\`\`bash
+```bash
 aws sts get-caller-identity
 aws configure get region
-\`\`\`
+```
 
-Ensure the \`Account\` from the first command and the Region from the second command match the Account and Region you are logged into in the AWS Console.
+Ensure the `Account` from the first command and the Region from the second command match the Account and Region you are logged into in the AWS Console.
 
 ### 2. Identify the Active User Pool ID
 
-The exact User Pool ID that your application is using is generated dynamically by Amplify and saved in your \`amplify_outputs.json\` file.
+The exact User Pool ID that your application is using is generated dynamically by Amplify and saved in your `amplify_outputs.json` file.
 
-Look in \`web/amplify_outputs.json\` and find the \`auth.user_pool_id\` property.
+Look in `web/amplify_outputs.json` and find the `auth.user_pool_id` property.
 
-\`\`\`json
+```json
 {
-"auth": {
-"user_pool_id": "ap-northeast-1_xxxxxxxxx",
-...
+  "auth": {
+    "user_pool_id": "ap-northeast-1_xxxxxxxxx"
+  }
 }
-}
-\`\`\`
+```
 
 ### 3. Check the Correct User Pool in the Console
 
 1. Log into the AWS Management Console with the account ID verified in step 1.
-2. Switch your AWS Console to the correct Region (e.g., \`ap-northeast-1\`).
+2. Switch your AWS Console to the correct Region (e.g., `ap-northeast-1`).
 3. Navigate to **Amazon Cognito** > **User Pools**.
 4. Search or look for the exact User Pool ID you found in step 2.
 
-If you don't see the User Pool ID, verify you are not looking at an older sandbox or another developer's sandbox instance. Amplify sandbox scopes resources by your local username (e.g., \`amplify-admin\` or your computer username).
+If you don't see the User Pool ID, verify you are not looking at an older sandbox or another developer's sandbox instance. Amplify sandbox scopes resources by your local username (e.g., `amplify-admin` or your computer username).
+
+</div>
+


### PR DESCRIPTION
## Summary
- Added site-wide bilingual support (JA/EN) across all 13 VitePress documentation pages with global header language toggle.
- Refactored documentation to eliminate content duplication (Single Source of Truth between test strategy and AI guidelines).
- Expanded VitePress sidebar navigation and index links to cover all documentation pages.
- Updated agent system workflows and rules for loop-engineering and verification gates.

## Atomic Commits
1. \eat(agent)\: update AI engineering OS workflows, shared definitions, and rules
2. \eat(vitepress)\: add site-wide language toggle theme component and sidebar navigation
3. \docs(vitepress)\: add bilingual support and fix structure in core specification, home, and showcase pages
4. \docs(vitepress)\: update AI development, testing strategy, and CI/CD specs with deduplicated bilingual content
5. \docs(vitepress)\: add bilingual support for operations, troubleshooting, and roadmap guides

## Test Evidence
- Static build passed: \
pm run docs:build\
- Checked 100% div v-if balance across all documents.
- Relative paths and security checks passed cleanly.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Atomic commits created
- [x] Build passes cleanly